### PR TITLE
fix: restrictive message cutoff

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -128,7 +128,7 @@
       "back-button": "Zum Dialogpartner",
       "join": "Dem Dialog beitreten",
       "go-to": "Gehe auf",
-      "enter-code": "Gebe den Code ein",
+      "enter-code": "Gib den Code ein",
       "open-chat": "Chat öffnen",
       "use-qr": "Oder nutze den QR-Code"
     },

--- a/src/app/api/chat/message-consolidation.test.ts
+++ b/src/app/api/chat/message-consolidation.test.ts
@@ -1,0 +1,65 @@
+import { Message } from 'ai';
+import { consolidateMessages } from './utils';
+import { describe, it, expect } from 'vitest';
+
+describe('consolidateMessages', () => {
+  it('should consolidate consecutive messages with the same role', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello', id: '1' },
+      { role: 'user', content: 'How are you?', id: '2' },
+      { role: 'assistant', content: 'I am good', id: '3' },
+      { role: 'assistant', content: 'How can I help?', id: '4' },
+    ];
+
+    const consolidated = consolidateMessages(messages);
+
+    expect(consolidated).toHaveLength(2);
+    expect(consolidated[0]?.content).toBe('Hello\n\nHow are you?');
+    expect(consolidated[1]?.content).toBe('I am good\n\nHow can I help?');
+  });
+
+  it('should not consolidate messages with different roles', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello', id: '1' },
+      { role: 'assistant', content: 'Hi there', id: '2' },
+      { role: 'user', content: 'How are you?', id: '3' },
+    ];
+
+    const consolidated = consolidateMessages(messages);
+
+    expect(consolidated).toHaveLength(3);
+    expect(consolidated[0]?.content).toBe('Hello');
+    expect(consolidated[1]?.content).toBe('Hi there');
+    expect(consolidated[2]?.content).toBe('How are you?');
+  });
+
+  it('should handle empty message array', () => {
+    const messages: Message[] = [];
+    const consolidated = consolidateMessages(messages);
+    expect(consolidated).toHaveLength(0);
+  });
+
+  it('should handle single message array', () => {
+    const messages: Message[] = [{ role: 'user', content: 'Hello', id: '1' }];
+
+    const consolidated = consolidateMessages(messages);
+    expect(consolidated).toHaveLength(1);
+    expect(consolidated[0]?.content).toBe('Hello');
+  });
+
+  it('should handle multiple consecutive messages of the same role', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'First', id: '1' },
+      { role: 'user', content: 'Second', id: '2' },
+      { role: 'user', content: 'Third', id: '3' },
+      { role: 'assistant', content: 'Reply 1', id: '4' },
+      { role: 'assistant', content: 'Reply 2', id: '5' },
+    ];
+
+    const consolidated = consolidateMessages(messages);
+
+    expect(consolidated).toHaveLength(2);
+    expect(consolidated[0]?.content).toBe('First\n\nSecond\n\nThird');
+    expect(consolidated[1]?.content).toBe('Reply 1\n\nReply 2');
+  });
+});

--- a/src/app/api/chat/message-cutoff.test.ts
+++ b/src/app/api/chat/message-cutoff.test.ts
@@ -35,8 +35,8 @@ describe('limitChatHistory', () => {
 
     const result = limitChatHistory({
       messages,
-      limitRecent: 4,
-      limitFirst: 2,
+      limitRecent: 2,
+      limitFirst: 1,
       characterLimit,
     });
 
@@ -64,8 +64,8 @@ describe('limitChatHistory', () => {
 
     const result = limitChatHistory({
       messages,
-      limitRecent: 4,
-      limitFirst: 2,
+      limitRecent: 2,
+      limitFirst: 1,
       characterLimit: 500, // Set a lower character limit
     });
 
@@ -89,8 +89,8 @@ describe('limitChatHistory', () => {
 
     const result = limitChatHistory({
       messages,
-      limitRecent: 4,
-      limitFirst: 2,
+      limitRecent: 2,
+      limitFirst: 1,
       characterLimit: 1500, // Set a character limit that can't fit all mandatory messages
     });
 

--- a/src/app/api/chat/message-cutoff.test.ts
+++ b/src/app/api/chat/message-cutoff.test.ts
@@ -2,203 +2,101 @@ import { describe, it, expect } from 'vitest';
 import { limitChatHistory } from './utils';
 import { Message } from 'ai';
 
-const characterLimit = 20000;
+const characterLimit = 2000;
+
+// Helper function to generate random string of specified length
+function generateRandomString(length: number): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 ';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+// Helper function to create a message
+function createMessage(role: 'user' | 'assistant', content: string): Message {
+  return { role, content, id: generateRandomString(10) };
+}
 
 describe('limitChatHistory', () => {
-  // Create a sample unbalanced conversation with more user messages than assistant messages
-  const unbalancedHistory: Message[] = [
-    { role: 'user', content: 'Hello!', id: '0' },
-    { role: 'assistant', content: 'Hi there! How can I help you today?', id: '0' },
-    { role: 'user', content: 'I have a question about TypeScript.', id: '1' },
-    { role: 'user', content: 'Actually, can you explain React hooks?', id: '2' },
-    {
-      role: 'assistant',
-      content:
-        'React hooks are functions that let you use state and lifecycle features in functional components.',
-      id: '3',
-    },
-    { role: 'user', content: 'What about useEffect?', id: '4' },
-    { role: 'user', content: 'And useState?', id: '5' },
-    {
-      role: 'assistant',
-      content: 'useEffect lets you perform side effects in function components.',
-      id: '6',
-    },
-    { role: 'user', content: 'Thanks! One more thing about useContext?', id: '7' },
-  ];
+  it('should include first 2 and last 4 messages regardless of content length', () => {
+    // Create messages with varying lengths
+    const messages: Message[] = [
+      createMessage('user', generateRandomString(1000)), // First message
+      createMessage('assistant', generateRandomString(1000)), // Second message
+      createMessage('user', generateRandomString(1000)), // Will be omitted
+      createMessage('assistant', generateRandomString(1000)), // Will be omitted
+      createMessage('user', generateRandomString(1000)), // Last 4 messages
+      createMessage('assistant', generateRandomString(1000)),
+      createMessage('user', generateRandomString(1000)),
+      createMessage('assistant', generateRandomString(1000)),
+    ];
 
-  it('should return the original array if messages length is less than limit', () => {
     const result = limitChatHistory({
-      messages: unbalancedHistory.slice(0, 5),
-      limitRecent: 10,
-      characterLimit,
-    });
-    expect(result).toHaveLength(4);
-  });
-
-  it('should throw an error if limit is not even', () => {
-    expect(() =>
-      limitChatHistory({
-        messages: unbalancedHistory,
-        limitRecent: 5,
-        characterLimit,
-      }),
-    ).toThrow();
-  });
-
-  it('should keep the first message by default and balance the rest', () => {
-    const result = limitChatHistory({
-      messages: unbalancedHistory,
-      limitRecent: 6,
-      characterLimit,
-    });
-
-    // join consecutive messages
-    expect(result).toHaveLength(7);
-    expect(result[0]).toEqual(unbalancedHistory[0]); // System message
-
-    // Count roles in the result
-    const userCount = result.filter((m) => m.role === 'user').length;
-    const assistantCount = result.filter((m) => m.role === 'assistant').length;
-    expect(userCount).toBeLessThanOrEqual(4); // At most 4 user messages
-    expect(assistantCount).toBeGreaterThanOrEqual(2); // At least 3 assistant messages
-
-    // Should include most recent messages of each type
-    expect(result).toContainEqual(unbalancedHistory.at(-1)); // Most recent user message
-    expect(result).toContainEqual(unbalancedHistory.at(-2)); // Most recent assistant message
-  });
-
-  it('should keep first n messages intact when keepFirstN is specified', () => {
-    const result = limitChatHistory({
-      messages: unbalancedHistory,
-      limitRecent: 8,
-      limitFirst: 3,
-      characterLimit,
-    });
-
-    expect(result).toHaveLength(7);
-
-    // First 3 messages should be preserved in order
-    expect(result[0]).toEqual(unbalancedHistory[0]);
-    expect(result[2]?.content).toEqual(
-      `${unbalancedHistory[2]?.content}\n\n${unbalancedHistory[3]?.content}`,
-    );
-    expect(result[3]).toEqual(unbalancedHistory[4]);
-
-    // Count roles in the remaining results
-    const remainingMessages = result.slice(3);
-    const userCount = remainingMessages.filter((m) => m.role === 'user').length;
-    const assistantCount = remainingMessages.filter((m) => m.role === 'assistant').length;
-
-    // Should be roughly balanced with preference for most recent
-    expect(userCount + assistantCount).toBe(4);
-
-    // Should include most recent messages
-    expect(result).toContainEqual(unbalancedHistory.at(-1)); // Most recent user
-    expect(result).toContainEqual(unbalancedHistory.at(-1)); // Most recent assistant
-  });
-});
-
-describe('limitChatHistory', () => {
-  // Create a balanced conversation with alternating user and assistant messages
-  const balancedHistory: Message[] = [
-    { role: 'user', content: 'Hello!', id: '0' },
-    { role: 'assistant', content: 'Hi there! How can I help you today?', id: '1' },
-    { role: 'user', content: 'I have a question about TypeScript.', id: '2' },
-    { role: 'assistant', content: 'Sure, what would you like to know about TypeScript?', id: '3' },
-    { role: 'user', content: 'How do interfaces work?', id: '4' },
-    {
-      role: 'assistant',
-      content: 'Interfaces in TypeScript define the shape of objects and provide type checking.',
-      id: '5',
-    },
-    { role: 'user', content: 'What about generics?', id: '6' },
-    {
-      role: 'assistant',
-      content:
-        'Generics allow you to create reusable components that work with a variety of types.',
-      id: '7',
-    },
-    { role: 'user', content: 'Thanks! That was helpful.', id: '8' },
-    {
-      role: 'assistant',
-      content: "You're welcome! Let me know if you have any other questions.",
-      id: '8',
-    },
-    {
-      role: 'user',
-      content: 'This is the most recent user question',
-      id: '9',
-    },
-  ];
-
-  // Tests for balanced history
-  it('should handle balanced conversation with alternating messages', () => {
-    const result = limitChatHistory({
-      messages: balancedHistory,
-      limitRecent: 2,
+      messages,
+      limitRecent: 4,
       limitFirst: 2,
       characterLimit,
     });
 
-    expect(result).toHaveLength(5);
-
-    // First message should be preserved
-    expect(result[0]).toEqual(balancedHistory[0]);
-
-    // Count roles in the result (excluding the system message)
-    const userCount = result.filter((m) => m.role === 'user').length;
-    const assistantCount = result.filter((m) => m.role === 'assistant').length;
-
-    // Should have one more user message, since the most recent user message comes last
-    expect(userCount).toBe(assistantCount + 1);
-
-    // Should include most recent messages
-    expect(result).toContainEqual(balancedHistory.at(-2)); // Recent user message
-    expect(result).toContainEqual(balancedHistory.at(-1)); // Recent assistant message
+    // Should include first 2 and last 4 messages
+    expect(result.length).toBe(6);
+    expect(result[0]?.content).toBe(messages?.[0]?.content);
+    expect(result[1]?.content).toBe(messages?.[1]?.content);
+    expect(result[2]?.content).toBe(messages?.[4]?.content);
+    expect(result[3]?.content).toBe(messages?.[5]?.content);
+    expect(result[4]?.content).toBe(messages?.[6]?.content);
+    expect(result[5]?.content).toBe(messages?.[7]?.content);
   });
 
-  it('should maintain chronological order in balanced conversation', () => {
+  it('should include most recent messages up to character limit after mandatory messages', () => {
+    const messages: Message[] = [
+      createMessage('user', generateRandomString(100)), // First message
+      createMessage('assistant', generateRandomString(100)), // Second message
+      createMessage('user', generateRandomString(1000)), // Will be omitted
+      createMessage('assistant', generateRandomString(1000)), // Will be omitted
+      createMessage('user', generateRandomString(100)), // Last 4 messages
+      createMessage('assistant', generateRandomString(100)),
+      createMessage('user', generateRandomString(100)),
+      createMessage('assistant', generateRandomString(100)),
+    ];
+
     const result = limitChatHistory({
-      messages: balancedHistory,
-      limitRecent: 2,
-      limitFirst: 4,
-      characterLimit,
+      messages,
+      limitRecent: 4,
+      limitFirst: 2,
+      characterLimit: 500, // Set a lower character limit
     });
 
-    expect(result).toHaveLength(7);
-
-    // Check that the order matches the original chronological order
-    for (let i = 1; i < result.length; i++) {
-      const resultIndex = balancedHistory.findIndex(
-        (m) => m.role === result[i]?.role && m.content === result[i]?.content,
-      );
-      const prevResultIndex = balancedHistory.findIndex(
-        (m) => m.role === result[i - 1]?.role && m.content === result[i - 1]?.content,
-      );
-
-      expect(resultIndex).toBeGreaterThan(prevResultIndex);
-    }
+    // Should include first 2 and as many of the last 4 as possible within character limit
+    expect(result.length).toBeLessThanOrEqual(6);
+    expect(result[0]?.content).toBe(messages?.[0]?.content);
+    expect(result[1]?.content).toBe(messages?.[1]?.content);
   });
 
-  // Test for keeping first n messages in a balanced conversation
-  it('should keep first n messages intact in balanced conversation', () => {
+  it('should handle messages that exceed character limit even with mandatory messages', () => {
+    const messages: Message[] = [
+      createMessage('user', generateRandomString(1000)), // First message
+      createMessage('assistant', generateRandomString(1000)), // Second message
+      createMessage('user', generateRandomString(1000)), // Will be omitted
+      createMessage('assistant', generateRandomString(1000)), // Will be omitted
+      createMessage('user', generateRandomString(1000)), // Last 4 messages
+      createMessage('assistant', generateRandomString(1000)),
+      createMessage('user', generateRandomString(1000)),
+      createMessage('assistant', generateRandomString(1000)),
+    ];
+
     const result = limitChatHistory({
-      messages: balancedHistory,
-      limitRecent: 2,
-      limitFirst: 4,
-      characterLimit,
+      messages,
+      limitRecent: 4,
+      limitFirst: 2,
+      characterLimit: 1500, // Set a character limit that can't fit all mandatory messages
     });
 
-    expect(result).toHaveLength(7);
-
-    // First 3 messages should be preserved in order
-    expect(result[0]).toEqual(balancedHistory[0]);
-    expect(result[1]).toEqual(balancedHistory[1]);
-    expect(result[2]).toEqual(balancedHistory[2]);
-
-    // Should have most recent messages for the remaining slots
-    expect(result).toContainEqual(balancedHistory.at(-1)); // Most recent assistant
-    expect(result).toContainEqual(balancedHistory.at(-2)); // Most recent user
+    // Should still include first 2 messages and as many of the last 4 as possible
+    expect(result.length).toBeLessThanOrEqual(6);
+    expect(result[0]?.content).toBe(messages?.[0]?.content);
+    expect(result[1]?.content).toBe(messages?.[1]?.content);
   });
 });

--- a/src/app/api/chat/utils.ts
+++ b/src/app/api/chat/utils.ts
@@ -27,6 +27,13 @@ export function consolidateMessages(messages: Array<Message>): Array<Message> {
   return consolidatedMessages;
 }
 
+/**
+ * Limits the chat history to the most recent messages, keeping the first N messages and the last N messages.
+ * @param messages - The messages to limit.
+ * @param limitRecent - The number of recent message-pairs to keep e.g. 2 means 2 user messages and 2 assistant messages.
+ * @param limitFirst - The number of first message-pairs to keep.
+ * @param characterLimit - The maximum number of characters to keep.
+ */
 export function limitChatHistory({
   messages,
   limitRecent,
@@ -39,22 +46,13 @@ export function limitChatHistory({
   characterLimit: number;
 }): Array<Message> {
   // Validate inputs
-  if (limitRecent % 2 !== 0 || messages.length === 0) {
-    throw new Error(
-      'Limit must be an even number to ensure equal distribution between user and assistant messages',
-    );
-  }
-
-  if (limitFirst < 0) {
-    throw new Error('keepFirstN must be a non-negative number');
-  }
 
   // First consolidate consecutive messages from the same role
   const consolidatedMessages = consolidateMessages(messages);
 
   // Always include the last user message even if limitRecent == 0
-  limitRecent = limitRecent;
-  limitFirst = limitFirst - 1;
+  limitRecent = limitRecent * 2;
+  limitFirst = limitFirst * 2 - 1;
 
   // If we have fewer messages than the limits, just return all messages
   if (consolidatedMessages.length <= limitFirst + limitRecent) {
@@ -88,7 +86,6 @@ export function limitChatHistory({
     if (frontIndex <= limitFirst) {
       frontMessages.push(frontMessage);
       includedIndices.add(frontIndex);
-      frontIndex++;
     }
 
     if (backMessage === undefined) continue;
@@ -98,12 +95,13 @@ export function limitChatHistory({
       backMessages.unshift(backMessage);
       includedIndices.add(backIndex);
     }
+    manadatoryMessagesIncluded =
+      frontIndex > limitFirst && backIndex < consolidatedMessages.length - limitRecent;
     backIndex--;
-
-    manadatoryMessagesIncluded = frontIndex > limitFirst && backIndex < limitRecent;
+    frontIndex++;
   }
 
-  // Mark all messages not in includedIndices as omitted
+  // Mark all messages not in includedIndices as omitted this is left in for debugging purposes
   for (let i = 0; i < consolidatedMessages.length; i++) {
     if (!includedIndices.has(i)) {
       omittedIndices.add(i);


### PR DESCRIPTION
modified: logic for message cutoff; will now always include the first and last messages specified and apply character limit afterwards