### PR TITLE
feat: parity-update-shared-chat

### DIFF
--- a/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/page.tsx
+++ b/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/page.tsx
@@ -52,7 +52,7 @@ export default async function Page(context: PageContext) {
         );
 
   const maybeSignedPictureUrl = await getMaybeSignedUrlFromS3Get({
-    key: `shared-chats/${sharedSchoolChat.id}/avatar`,
+    key: sharedSchoolChat.pictureId ? `shared-chats/${sharedSchoolChat.id}/avatar` : undefined,
   });
   return (
     <div className="w-full p-6 overflow-auto">

--- a/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/utils.ts
+++ b/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/utils.ts
@@ -1,3 +1,4 @@
+import { getMaybeSignedUrlFromS3Get } from '@/s3';
 import {
   IntelliPointsPercentageValue,
   intelliPointsPercentageValueSchema,
@@ -5,6 +6,10 @@ import {
   usageTimeValueSchema,
 } from './schema';
 import { customAlphabet } from 'nanoid';
+import { SharedSchoolConversationModel } from '@/db/schema';
+
+export type SharedChatWithImage = SharedSchoolConversationModel & { maybeSignedPictureUrl: string | undefined };
+
 
 export function calculateTimeLeftBySharedChat({
   startedAt,
@@ -55,4 +60,18 @@ export function getMaxUsageTimeValueOrDefault(
 export function generateInviteCode(length = 8) {
   const nanoid = customAlphabet('123456789ABCDEFGHIJKLMNPQRSTUVWXYZ', length);
   return nanoid().toUpperCase();
+}
+
+export async function enrichSharedChatWithPictureUrl({
+  sharedChats,
+}: {
+  sharedChats: SharedSchoolConversationModel[];
+}): Promise<SharedChatWithImage[]> {
+  return await Promise.all(sharedChats.map(async (sharedChat) => ({
+    ...sharedChat,
+    maybeSignedPictureUrl: await getMaybeSignedUrlFromS3Get({
+        key: sharedChat.pictureId ? `shared-chats/${sharedChat.id}/avatar` : undefined,
+      }),
+    })),
+  );
 }

--- a/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/utils.ts
+++ b/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/utils.ts
@@ -8,8 +8,9 @@ import {
 import { customAlphabet } from 'nanoid';
 import { SharedSchoolConversationModel } from '@/db/schema';
 
-export type SharedChatWithImage = SharedSchoolConversationModel & { maybeSignedPictureUrl: string | undefined };
-
+export type SharedChatWithImage = SharedSchoolConversationModel & {
+  maybeSignedPictureUrl: string | undefined;
+};
 
 export function calculateTimeLeftBySharedChat({
   startedAt,
@@ -67,9 +68,10 @@ export async function enrichSharedChatWithPictureUrl({
 }: {
   sharedChats: SharedSchoolConversationModel[];
 }): Promise<SharedChatWithImage[]> {
-  return await Promise.all(sharedChats.map(async (sharedChat) => ({
-    ...sharedChat,
-    maybeSignedPictureUrl: await getMaybeSignedUrlFromS3Get({
+  return await Promise.all(
+    sharedChats.map(async (sharedChat) => ({
+      ...sharedChat,
+      maybeSignedPictureUrl: await getMaybeSignedUrlFromS3Get({
         key: sharedChat.pictureId ? `shared-chats/${sharedChat.id}/avatar` : undefined,
       }),
     })),

--- a/src/app/(authed)/(dialog)/shared-chats/page.tsx
+++ b/src/app/(authed)/(dialog)/shared-chats/page.tsx
@@ -2,6 +2,7 @@ import Refresh from '@/components/refresh';
 import { dbGetSharedChatsByUserId } from '@/db/functions/shared-school-chat';
 import { getUser } from '@/auth/utils';
 import { SharedChatContainer } from './shared-chat-container';
+import { enrichSharedChatWithPictureUrl } from './[sharedSchoolChatId]/utils';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,10 +10,12 @@ export default async function Page() {
   const user = await getUser();
   const _sharedChats = await dbGetSharedChatsByUserId({ userId: user.id });
   const sharedChats = _sharedChats.filter((c) => c.name !== '');
+  const enrichedSharedChats = await enrichSharedChatWithPictureUrl({ sharedChats });
+  console.log(enrichedSharedChats);
   return (
     <main className="w-full p-6">
       <Refresh />
-      <SharedChatContainer sharedChats={sharedChats} user={user} />
+      <SharedChatContainer sharedChats={enrichedSharedChats} user={user} />
     </main>
   );
 }

--- a/src/app/(authed)/(dialog)/shared-chats/shared-chat-container.tsx
+++ b/src/app/(authed)/(dialog)/shared-chats/shared-chat-container.tsx
@@ -3,7 +3,6 @@
 import HeaderPortal from '../header-portal';
 import { ToggleSidebarButton } from '@/components/navigation/sidebar/collapsible-sidebar';
 import ProfileMenu from '@/components/navigation/profile-menu';
-import { SharedSchoolConversationModel } from '@/db/schema';
 import React from 'react';
 import { cn } from '@/utils/tailwind';
 import Link from 'next/link';

--- a/src/app/(authed)/(dialog)/shared-chats/shared-chat-container.tsx
+++ b/src/app/(authed)/(dialog)/shared-chats/shared-chat-container.tsx
@@ -13,9 +13,9 @@ import SharedChatItem from './shared-chat-item';
 import SearchBarInput from '@/components/search-bar';
 import { type UserAndContext } from '@/auth/types';
 import { useTranslations } from 'next-intl';
-
+import { SharedChatWithImage } from './[sharedSchoolChatId]/utils';
 type SharedChatContainerProps = {
-  sharedChats: SharedSchoolConversationModel[];
+  sharedChats: SharedChatWithImage[];
   user: UserAndContext;
 };
 
@@ -70,7 +70,7 @@ export function SharedChatContainer({ sharedChats, user }: SharedChatContainerPr
   );
 }
 
-function filterSharedChats(sharedChats: SharedSchoolConversationModel[], input: string) {
+function filterSharedChats(sharedChats: SharedChatWithImage[], input: string) {
   const lowerCaseInput = input.toLowerCase();
 
   return sharedChats.filter((sharedChat) => {

--- a/src/app/(authed)/(dialog)/shared-chats/shared-chat-item.tsx
+++ b/src/app/(authed)/(dialog)/shared-chats/shared-chat-item.tsx
@@ -10,17 +10,19 @@ import { useRouter } from 'next/navigation';
 import { dbDeleteSharedChatAction } from './actions';
 import { cn } from '@/utils/tailwind';
 import { truncateClassName } from '@/utils/tailwind/truncate';
-import { calculateTimeLeftBySharedChat } from './[sharedSchoolChatId]/utils';
+import { calculateTimeLeftBySharedChat, SharedChatWithImage } from './[sharedSchoolChatId]/utils';
 import CountDownTimer from './_components/count-down';
 import { useTranslations } from 'next-intl';
-
-type SharedChatItemProps = SharedSchoolConversationModel;
+import { EmptyImageIcon } from '@/components/icons/empty-image';
+import Image from 'next/image';
+type SharedChatItemProps = SharedChatWithImage;
 
 export default function SharedChatItem({ ...sharedSchoolChat }: SharedChatItemProps) {
   const toast = useToast();
   const router = useRouter();
   const t = useTranslations('shared-chats');
   const tCommon = useTranslations('common');
+
 
   function handleDeleteSharedChat() {
     dbDeleteSharedChatAction({ id: sharedSchoolChat.id })
@@ -34,12 +36,27 @@ export default function SharedChatItem({ ...sharedSchoolChat }: SharedChatItemPr
   }
 
   const timeLeft = calculateTimeLeftBySharedChat(sharedSchoolChat);
-
+  console.log(sharedSchoolChat.maybeSignedPictureUrl);
   return (
     <Link
       href={`/shared-chats/${sharedSchoolChat.id}`}
       className="flex gap-2 items-center border rounded-enterprise-md p-4 hover:border-primary"
     >
+        <figure
+        className="w-11 h-11 bg-light-gray rounded-enterprise-sm flex justify-center items-center"
+        style={{ minWidth: '44px' }}
+      >
+        {sharedSchoolChat.maybeSignedPictureUrl !== undefined && (
+          <Image
+            src={sharedSchoolChat.maybeSignedPictureUrl}
+            alt={`${sharedSchoolChat.name} Avatar`}
+            width={44}
+            height={44}
+            className="rounded-enterprise-sm"
+          />
+        )}
+        {sharedSchoolChat.maybeSignedPictureUrl === undefined && <EmptyImageIcon className="w-4 h-4" />}
+      </figure>
       <div className="min-w-0">
         <h1 className={cn('font-medium text-primary', truncateClassName)}>
           {sharedSchoolChat.name}

--- a/src/app/(authed)/(dialog)/shared-chats/shared-chat-item.tsx
+++ b/src/app/(authed)/(dialog)/shared-chats/shared-chat-item.tsx
@@ -2,7 +2,6 @@
 
 import DestructiveActionButton from '@/components/common/destructive-action-button';
 import { useToast } from '@/components/common/toast';
-import { SharedSchoolConversationModel } from '@/db/schema';
 import ShareIcon from '@/components/icons/share';
 import TrashIcon from '@/components/icons/trash';
 import Link from 'next/link';
@@ -23,7 +22,6 @@ export default function SharedChatItem({ ...sharedSchoolChat }: SharedChatItemPr
   const t = useTranslations('shared-chats');
   const tCommon = useTranslations('common');
 
-
   function handleDeleteSharedChat() {
     dbDeleteSharedChatAction({ id: sharedSchoolChat.id })
       .then(() => {
@@ -42,7 +40,7 @@ export default function SharedChatItem({ ...sharedSchoolChat }: SharedChatItemPr
       href={`/shared-chats/${sharedSchoolChat.id}`}
       className="flex gap-2 items-center border rounded-enterprise-md p-4 hover:border-primary"
     >
-        <figure
+      <figure
         className="w-11 h-11 bg-light-gray rounded-enterprise-sm flex justify-center items-center"
         style={{ minWidth: '44px' }}
       >
@@ -55,7 +53,9 @@ export default function SharedChatItem({ ...sharedSchoolChat }: SharedChatItemPr
             className="rounded-enterprise-sm"
           />
         )}
-        {sharedSchoolChat.maybeSignedPictureUrl === undefined && <EmptyImageIcon className="w-4 h-4" />}
+        {sharedSchoolChat.maybeSignedPictureUrl === undefined && (
+          <EmptyImageIcon className="w-4 h-4" />
+        )}
       </figure>
       <div className="min-w-0">
         <h1 className={cn('font-medium text-primary', truncateClassName)}>

--- a/src/components/chat/sources/citation.tsx
+++ b/src/components/chat/sources/citation.tsx
@@ -48,7 +48,7 @@ export default function Citation({
 
   const displayHostname = parseHostname(source.link);
   let displayTitle = '';
-  if (isLoading && source.name === undefined) {
+  if (isLoading && !source.name) {
     displayTitle = 'Titel wird geladen...';
   } else {
     displayTitle = truncateText(source.name || data?.name || '', 30);


### PR DESCRIPTION
- Added functionality to enrich shared chats with picture URLs by implementing `enrichSharedChatWithPictureUrl`.
- Updated `SharedChatContainer` and `SharedChatItem` components to handle the new `SharedChatWithImage` type, which includes the picture URL.
- Adjusted the rendering logic in `SharedChatItem` to display user avatars or a placeholder icon based on the availability of the picture URL.
ticket: [TD-231](https://fwu-de.atlassian.net/browse/TD-231)

[TD-231]: https://fwu-de.atlassian.net/browse/TD-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ