### PR TITLE
fix: on shared-school chat save navigate back to preview

### DIFF
--- a/e2e/tests/create-shared-chat.test.ts
+++ b/e2e/tests/create-shared-chat.test.ts
@@ -115,7 +115,10 @@ test('teacher can login, create and delete shared chat, student can join chat', 
   await firstSharedChat.click();
 
   await page.waitForURL('/shared-chats/**');
-
+  const stopSharingButton = page.getByRole('button', { name: 'Stop' });
+  if (await stopSharingButton.isVisible()) {
+    await stopSharingButton.click();
+  }
   // test share page
   await page.selectOption('#Telli-Points', '25');
   await page.selectOption('#maxUsage', '30');

--- a/e2e/tests/create-shared-chat.test.ts
+++ b/e2e/tests/create-shared-chat.test.ts
@@ -45,7 +45,7 @@ test('teacher can login, create and join shared chat', async ({ page }) => {
     .getByText('Absolutismus unter Ludwig XIV – Gruppe 1 Soldaten')
     .first();
   await expect(sharedChatName).toBeVisible();
-  
+
   const stopSharingButton = page.getByRole('button', { name: 'Stop' });
   if (await stopSharingButton.isVisible()) {
     await stopSharingButton.click();

--- a/e2e/tests/create-shared-chat.test.ts
+++ b/e2e/tests/create-shared-chat.test.ts
@@ -45,7 +45,11 @@ test('teacher can login, create and join shared chat', async ({ page }) => {
     .getByText('Absolutismus unter Ludwig XIV – Gruppe 1 Soldaten')
     .first();
   await expect(sharedChatName).toBeVisible();
-
+  
+  const stopSharingButton = page.getByRole('button', { name: 'Stop' });
+  if (await stopSharingButton.isVisible()) {
+    await stopSharingButton.click();
+  }
   // test share page
   await page.selectOption('#Telli-Points', '50');
   await page.selectOption('#maxUsage', '30');

--- a/e2e/tests/create-shared-chat.test.ts
+++ b/e2e/tests/create-shared-chat.test.ts
@@ -35,7 +35,9 @@ test('teacher can login, create and join shared chat', async ({ page }) => {
   const submitButton = page.getByRole('button', { name: 'Szenario erstellen' });
   await expect(submitButton).toBeVisible();
   await submitButton.click();
-
+  const firstSharedChat = page.getByRole('link', { name: 'Absolutismus unter Ludwig XIV' }).first();
+  await expect(firstSharedChat).toBeVisible();
+  await firstSharedChat.click();
   await page.waitForURL('/shared-chats/**');
 
   // check if created with right name
@@ -108,6 +110,10 @@ test('teacher can login, create and delete shared chat, student can join chat', 
   await expect(submitButton).toBeVisible();
   await submitButton.click();
 
+  const firstSharedChat = page.getByRole('link', { name: 'Absolutismus unter Ludwig XIV' }).first();
+  await expect(firstSharedChat).toBeVisible();
+  await firstSharedChat.click();
+
   await page.waitForURL('/shared-chats/**');
 
   // test share page
@@ -137,7 +143,7 @@ test('teacher can login, create and delete shared chat, student can join chat', 
   await startButton.click();
 
   await page.getByPlaceholder('Wie kann ich Dir helfen?').fill('Was lernen wir hier?');
-  await page.getByLabel('Send Message').click();
+  await page.keyboard.press('Enter');
   await page.getByTitle('Kopieren').click();
 
   await expect(page.getByLabel('assistant message 1')).toContainText('Ludwig XIV');

--- a/src/app/(authed)/(dialog)/characters/editor/[characterId]/character-form.tsx
+++ b/src/app/(authed)/(dialog)/characters/editor/[characterId]/character-form.tsx
@@ -194,7 +194,7 @@ export default function CharacterForm({
         if (!isCreating) {
           toast.success(tToast('delete-toast-success'));
         }
-        // replace instead of push to avoid the back button to show a 404 when navigating back to the now non existing character
+        // replace instead of push to avoid showing a 404 when navigating back to the now non existing character
         router.replace(backUrl);
       })
       .catch(() => {

--- a/src/app/(authed)/(dialog)/characters/editor/[characterId]/character-form.tsx
+++ b/src/app/(authed)/(dialog)/characters/editor/[characterId]/character-form.tsx
@@ -194,8 +194,8 @@ export default function CharacterForm({
         if (!isCreating) {
           toast.success(tToast('delete-toast-success'));
         }
-
-        router.push(backUrl);
+        // replace instead of push to avoid the back button to show a 404 when navigating back to the now non existing character
+        router.replace(backUrl);
       })
       .catch(() => {
         toast.error(tToast('delete-toast-error'));

--- a/src/app/(authed)/(dialog)/custom/editor/[customgptId]/custom-gpt-form.tsx
+++ b/src/app/(authed)/(dialog)/custom/editor/[customgptId]/custom-gpt-form.tsx
@@ -212,7 +212,8 @@ export default function CustomGptForm({
           toast.success(tToast('delete-toast-success'));
         }
 
-        router.push(backUrl);
+        // replace instead of push to avoid the back button to show a 404 when navigating back to the now non existing custom gpt
+        router.replace(backUrl);
       })
       .catch(() => {
         toast.error(tToast('delete-toast-error'));

--- a/src/app/(authed)/(dialog)/custom/editor/[customgptId]/custom-gpt-form.tsx
+++ b/src/app/(authed)/(dialog)/custom/editor/[customgptId]/custom-gpt-form.tsx
@@ -212,7 +212,7 @@ export default function CustomGptForm({
           toast.success(tToast('delete-toast-success'));
         }
 
-        // replace instead of push to avoid the back button to show a 404 when navigating back to the now non existing custom gpt
+        // replace instead of push to avoid showing a 404 when navigating back to the now non existing custom gpt
         router.replace(backUrl);
       })
       .catch(() => {

--- a/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/shared-school-chat-form.tsx
+++ b/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/shared-school-chat-form.tsx
@@ -144,7 +144,7 @@ export default function SharedSchoolChatForm({
         if (!isCreating) {
           toast.success(tToast('delete-toast-success'));
         }
-        // replace instead of push to avoid the back button to show a 404 when navigating back to the now non existing shared chat
+        // replace instead of push to avoid showing a 404 when navigating back to the now non existing shared chat
         router.replace(backUrl);
       })
       .catch(() => {

--- a/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/shared-school-chat-form.tsx
+++ b/src/app/(authed)/(dialog)/shared-chats/[sharedSchoolChatId]/shared-school-chat-form.tsx
@@ -82,7 +82,7 @@ export default function SharedSchoolChatForm({
       attachedLinks: initalLinks,
     },
   });
-
+  const backUrl = '/shared-chats';
   const { fields } = useFieldArray({
     control,
     name: 'attachedLinks',
@@ -144,7 +144,8 @@ export default function SharedSchoolChatForm({
         if (!isCreating) {
           toast.success(tToast('delete-toast-success'));
         }
-        router.push('/shared-chats');
+        // replace instead of push to avoid the back button to show a 404 when navigating back to the now non existing shared chat
+        router.replace(backUrl);
       })
       .catch(() => {
         toast.error(tToast('delete-toast-error'));
@@ -167,13 +168,13 @@ export default function SharedSchoolChatForm({
     const data = getValues();
     onSubmit(data);
     toast.success(tToast('create-toast-success'));
-    router.push(`/shared-chats/${sharedSchoolChat.id}`);
+    router.replace(backUrl);
   }
   function handleNavigateBack() {
     if (isCreating) {
       handleDeleteSharedChat();
     }
-    router.push('/shared-chats');
+    router.push(backUrl);
   }
 
   return (

--- a/src/components/chat/floating-text.tsx
+++ b/src/components/chat/floating-text.tsx
@@ -9,21 +9,25 @@ import ChevronRightIcon from '../icons/chevron-right';
 
 export const dynamic = 'force-dynamic';
 
-const MAX_WIDTH = 450;
-const MAX_HEIGHT = 450;
-const INITIAL_MARGIN = 32;
-const MIN_MARGIN = 16;
-// Floating, minimizable, movable learning context dialog (desktop only)
+// Floating, minimizable, movable learning context dialog (desktop only) on mobile it's sticky on the top
 export function FloatingText({
   learningContext,
   dialogStarted,
   title,
   parentRef,
+  maxWidth,
+  maxHeight,
+  initialMargin,
+  minMargin,
 }: {
   learningContext: string;
   dialogStarted: boolean;
   title: string;
   parentRef: React.RefObject<HTMLDivElement>;
+  maxWidth: number;
+  maxHeight: number;
+  initialMargin: number;
+  minMargin: number;
 }) {
   const { isAtLeast } = useBreakpoints();
   const [isMinimized, setIsMinimized] = React.useState(false);
@@ -47,23 +51,24 @@ export function FloatingText({
     if (!parentRef.current) return { x, y };
     const parentRect = parentRef.current.getBoundingClientRect();
     const newX = Math.max(
-      parentRect.x + MIN_MARGIN,
-      Math.min(x, parentRect.width + parentRect.x - containerWidth - MIN_MARGIN),
+      parentRect.x + minMargin,
+      Math.min(x, parentRect.width + parentRect.x - containerWidth - minMargin),
     );
     const newY = Math.max(
-      parentRect.y + MIN_MARGIN,
-      Math.min(y, parentRect.height + parentRect.y - containerHeight - MIN_MARGIN),
+      parentRect.y + minMargin,
+      Math.min(y, parentRect.height + parentRect.y - containerHeight - minMargin),
     );
     return { x: newX, y: newY };
   }
 
   React.useEffect(() => {
     // Set initial position within parent
-    if (parentRef.current) {
+    if (parentRef.current && containerRef.current) {
       const parentRect = parentRef.current.getBoundingClientRect();
+      const containerRect = containerRef.current.getBoundingClientRect();
       setPosition({
-        x: parentRect.width + parentRect.x - MAX_WIDTH - INITIAL_MARGIN,
-        y: parentRect.height + parentRect.y - MAX_HEIGHT - INITIAL_MARGIN,
+        x: parentRect.width + parentRect.x - (containerRect?.width ?? maxWidth) - initialMargin,
+        y: parentRect.height + parentRect.y - (containerRect?.height ?? maxHeight) - initialMargin,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -159,12 +164,15 @@ export function FloatingText({
       className={cn(
         'flex flex-col z-50 bg-vidis-user-chat-background rounded-xl border select-none',
         // using string interpolations is extremly flaky, so we're using a static class name
-        'max-h-[450px]',
         isAtLeast.lg ? `absolute` : 'sticky',
-        isAtLeast.lg ? `max-w-[450px]` : 'w-[100%]',
         dragging ? 'cursor-grabbing' : 'cursor-grab',
       )}
-      style={{ left: position.x, top: isAtLeast.lg ? position.y : 0 }}
+      style={{
+        left: position.x,
+        top: isAtLeast.lg ? position.y : 0,
+        maxWidth: isAtLeast.lg ? maxWidth : '100%',
+        maxHeight: isAtLeast.lg ? maxHeight : '40%',
+      }}
     >
       <div
         className="flex items-center justify-between pl-4 py-2 rounded-t-xl mr-1"
@@ -187,13 +195,13 @@ export function FloatingText({
                 const newPos = {
                   x: Math.max(
                     0,
-                    Math.min(position.x, parentRect.width + parentRect.x - rect.width - MIN_MARGIN),
+                    Math.min(position.x, parentRect.width + parentRect.x - rect.width - minMargin),
                   ),
                   y: Math.max(
                     0,
                     Math.min(
                       position.y,
-                      parentRect.height + parentRect.y - rect.height - MIN_MARGIN,
+                      parentRect.height + parentRect.y - rect.height - minMargin,
                     ),
                   ),
                 };

--- a/src/components/chat/shared-chat.tsx
+++ b/src/components/chat/shared-chat.tsx
@@ -131,6 +131,10 @@ export default function SharedChat({
                   dialogStarted={dialogStarted}
                   title={t('excersise-title')}
                   parentRef={containerRef as React.RefObject<HTMLDivElement>}
+                  maxWidth={600}
+                  maxHeight={600}
+                  initialMargin={32}
+                  minMargin={16}
                 />
               )}
             {innerContent}


### PR DESCRIPTION
Increase the width and height of floating exercise text, change the behaviour when creating shared school chat to navigate back to overview instead of directly to the newly created scenario. This makes it consistent with the other two forms