### PR TITLE
fix: add max file size and embedding batch size constants

### DIFF
--- a/src/components/chat/upload-file-button.tsx
+++ b/src/components/chat/upload-file-button.tsx
@@ -7,7 +7,7 @@ import { ToastContextType, useToast } from '../common/toast';
 import { useConversation } from '../providers/conversation-provider';
 import AttachFileIcon from '../icons/attach-file';
 import { cn } from '@/utils/tailwind';
-import { SUPPORTED_FILE_EXTENSIONS } from '@/const';
+import { SUPPORTED_FILE_EXTENSIONS, MAX_FILE_SIZE } from '@/const';
 import { TranslationValues, useTranslations } from 'next-intl';
 import { NUMBER_OF_FILES_LIMIT } from '@/configuration-text-inputs/const';
 
@@ -35,7 +35,6 @@ export type UploadFileButtonProps = {
   countOfFiles?: number;
 };
 
-const MAX_FILE_SIZE = 5_000_000; // 5MB
 export async function handleSingleFile({
   file,
   setFiles,

--- a/src/const.ts
+++ b/src/const.ts
@@ -3,3 +3,6 @@ export type SUPPORTED_FILE_TYPE = (typeof SUPPORTED_FILE_EXTENSIONS)[number];
 
 /** enable local storage for character and shared chats this only affects shared chats */
 export const LOCAL_STORAGE_ENABLED = false;
+
+export const MAX_FILE_SIZE = 20_000_000; // 20MB
+export const EMBEDDING_BATCH_SIZE = 200;


### PR DESCRIPTION
- Increased MAX_FILE_SIZE constant to 20MB for each file.
- Added EMBEDDING_BATCH_SIZE constant set to 200 for processing text embeddings in batches. Create embedding syncronously to not run into rate limits