### PR TITLE
add script for signin and adapt readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ psql "postgresql://telli_dialog_db:test1234@127.0.0.1:5432/telli_dialog_db"
 If you start with a fresh database, do not forget to apply migrations, otherwise the application will not work.
 
 ```sh
+# with proper values in .env file
 pnpm db:migrate
+
+# with use of 1password-cli
+pnpm op:signin
+pnpm db:migrate:op
 ```
 
 You can now start the application:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "op": "op run --env-file=\"./.env\" --no-masking",
+    "op:signin": "eval $(op signin)",
     "dev": "ENVIRONMENT=development pnpm op -- next dev --turbo",
     "dev:e2e": "ENVIRONMENT=e2e pnpm op -- next dev --turbo",
     "dev:ssl": "next dev --experimental-https",


### PR DESCRIPTION
This commit adds a new script in package.json to signin with 1password using the 1password-cli.
The readme has been adapted accordingly.