### PR TITLE
feat: implement federal state CRUD operations and tests

### DIFF
--- a/e2e/tests/api/v1/admin/federal-state/create-federal-state.api.test.ts
+++ b/e2e/tests/api/v1/admin/federal-state/create-federal-state.api.test.ts
@@ -22,7 +22,8 @@ test('should create a new federal state with correct default values', async ({
     },
   });
   expect(response.ok()).toBeTruthy();
-  expect(await response.json()).toMatchObject({
+  const responseJson = await response.json();
+  expect(responseJson).toMatchObject({
     id,
     chatStorageTime: 120,
     designConfiguration: null,
@@ -100,4 +101,29 @@ test('should return 403 because authorization header is missing', async ({
     },
   });
   expect(response.status()).toBe(403);
+});
+
+test('should return 409 if federal state with same id already exists', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const id = 'Test-' + cnanoid(10);
+  const data = {
+    id,
+    teacherPriceLimit: 1000,
+    studentPriceLimit: 100,
+    decryptedApiKey: 'test-api-key',
+  };
+  // First creation
+  await request.post(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data,
+  });
+  // Duplicate creation
+  const response = await request.post(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data,
+  });
+  expect(response.status()).toBe(409);
 });

--- a/e2e/tests/api/v1/admin/federal-state/delete-federal-state.api.test.ts
+++ b/e2e/tests/api/v1/admin/federal-state/delete-federal-state.api.test.ts
@@ -1,0 +1,64 @@
+import test, { APIRequestContext, expect } from '@playwright/test';
+import { authorizationHeader } from '../../../../../utils/authorizationHeader';
+import { cnanoid } from '@/utils/random';
+
+const federalStateRoute = '/api/v1/admin/federal-states';
+
+test('should delete an existing federal state', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const id = 'Delete-' + cnanoid(10);
+  // Create first
+  await request.post(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data: {
+      id,
+      teacherPriceLimit: 1000,
+      studentPriceLimit: 100,
+      decryptedApiKey: 'delete-api-key',
+    },
+  });
+  // Delete
+  const response = await request.delete(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data: { id },
+  });
+  expect(response.ok()).toBeTruthy();
+  const json = await response.json();
+  expect(json.id).toBe(id);
+});
+
+test('should return 404 if federal state does not exist', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const id = 'NonExistent-' + cnanoid(10);
+  const response = await request.delete(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data: { id },
+  });
+  expect(response.status()).toBe(404);
+});
+
+test('should return 403 if authorization header is missing', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const id = 'Delete-' + cnanoid(10);
+  const response = await request.delete(federalStateRoute, {
+    data: { id },
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('should return 400 if id is missing', async ({ request }: { request: APIRequestContext }) => {
+  const response = await request.delete(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data: {},
+  });
+  expect(response.status()).toBe(400);
+});

--- a/e2e/tests/api/v1/admin/federal-state/get-federal-states.api.test.ts
+++ b/e2e/tests/api/v1/admin/federal-state/get-federal-states.api.test.ts
@@ -1,0 +1,29 @@
+import test, { APIRequestContext, expect } from '@playwright/test';
+import { authorizationHeader } from '../../../../../utils/authorizationHeader';
+
+const federalStateRoute = '/api/v1/admin/federal-states';
+
+test('should fetch all federal states with decryptedApiKey', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const response = await request.get(federalStateRoute, {
+    headers: { ...authorizationHeader },
+  });
+  expect(response.ok()).toBeTruthy();
+  const json = await response.json();
+  expect(Array.isArray(json.federalStates)).toBe(true);
+  if (json.federalStates.length > 0) {
+    expect(json.federalStates[0]).toHaveProperty('decryptedApiKey');
+  }
+});
+
+test('should return 403 if authorization header is missing', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const response = await request.get(federalStateRoute);
+  expect(response.status()).toBe(403);
+});

--- a/e2e/tests/api/v1/admin/federal-state/update-federal-state.api.test.ts
+++ b/e2e/tests/api/v1/admin/federal-state/update-federal-state.api.test.ts
@@ -1,0 +1,69 @@
+import test, { APIRequestContext, expect } from '@playwright/test';
+import { authorizationHeader } from '../../../../../utils/authorizationHeader';
+import { cnanoid } from '@/utils/random';
+
+const federalStateRoute = '/api/v1/admin/federal-states';
+
+test('should update an existing federal state', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const id = 'Test-' + cnanoid(10);
+  // Create first
+  await request.post(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data: {
+      id,
+      teacherPriceLimit: 1000,
+      studentPriceLimit: 100,
+      decryptedApiKey: 'test-api-key',
+    },
+  });
+  // Update
+  const response = await request.put(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data: {
+      id,
+      supportContact: 'updated-support-contact',
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const json = await response.json();
+  expect(json.supportContact).toBe('updated-support-contact');
+});
+
+test('should return 404 if federal state does not exist', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const id = 'NonExistent-' + cnanoid(10);
+  const response = await request.put(federalStateRoute, {
+    headers: { ...authorizationHeader },
+    data: {
+      id,
+      teacherPriceLimit: 1000,
+      studentPriceLimit: 100,
+      decryptedApiKey: 'test-api-key',
+    },
+  });
+  expect(response.status()).toBe(404);
+});
+
+test('should return 403 if authorization header is missing', async ({
+  request,
+}: {
+  request: APIRequestContext;
+}) => {
+  const id = 'Test-' + cnanoid(10);
+  const response = await request.put(federalStateRoute, {
+    data: {
+      id,
+      teacherPriceLimit: 1000,
+      studentPriceLimit: 100,
+      decryptedApiKey: 'test-api-key',
+    },
+  });
+  expect(response.status()).toBe(403);
+});

--- a/src/app/api/v1/admin/federal-states/route.ts
+++ b/src/app/api/v1/admin/federal-states/route.ts
@@ -1,11 +1,17 @@
 import { decryptMaybeValue, encrypt } from '@/db/crypto';
-import { dbGetAllFederalStates, dbUpsertFederalState } from '@/db/functions/federal-state';
+import {
+  dbGetAllFederalStates,
+  dbUpdateFederalState,
+  dbInsertFederalState,
+  dbGetFederalStateById,
+  dbDeleteFederalState,
+} from '@/db/functions/federal-state';
 import { federalStateTable } from '@/db/schema';
 import { validateApiKeyByHeadersWithResult } from '@/db/utils';
 import { env } from '@/env';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { createInsertSchema } from 'drizzle-zod';
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod';
 
 export async function GET(req: NextRequest) {
   const [error] = validateApiKeyByHeadersWithResult(req.headers);
@@ -39,9 +45,18 @@ const federalStateCreateSchema = createInsertSchema(federalStateTable)
     decryptedApiKey: z.string().nullable(),
   });
 
+const federalStateUpdateSchema = createUpdateSchema(federalStateTable)
+  .omit({
+    encryptedApiKey: true,
+    createdAt: true,
+  })
+  .extend({
+    decryptedApiKey: z.string().nullable().optional(),
+    id: z.string(),
+  });
+
 /**
- * Creates a new federal state record or updates an existing one if
- * there is already a record with the given id.
+ * Creates a new federal state record.
  * @param request
  * @returns 201 on success, 403 on forbidden, 500 on error
  */
@@ -55,18 +70,95 @@ export async function POST(request: NextRequest) {
   const federalStateToCreate = federalStateCreateSchema.parse(body);
 
   const encryptedApiKey =
-    federalStateToCreate.decryptedApiKey !== null
+    federalStateToCreate.decryptedApiKey != null
       ? encrypt({
           text: federalStateToCreate.decryptedApiKey,
           plainEncryptionKey: env.encryptionKey,
         })
       : null;
+  const existingFederalState = await dbGetFederalStateById(federalStateToCreate.id);
+  console.log('existingFederalState', existingFederalState);
+  if (existingFederalState !== undefined) {
+    return NextResponse.json(
+      { error: `Federal state with id ${federalStateToCreate.id} already exists` },
+      { status: 409 },
+    );
+  }
+  const inserted = await dbInsertFederalState({ ...federalStateToCreate, encryptedApiKey });
 
-  const upserted = await dbUpsertFederalState({ ...federalStateToCreate, encryptedApiKey });
-
-  if (upserted === undefined) {
-    return NextResponse.json({ error: 'Could not upsert federal state' }, { status: 500 });
+  if (inserted === undefined) {
+    return NextResponse.json({ error: 'Could not insert federal state' }, { status: 500 });
   }
 
-  return NextResponse.json(upserted, { status: 201 });
+  return NextResponse.json(inserted, { status: 201 });
+}
+/**
+ * Updates an existing federal state record.
+ * @param request
+ * @returns 200 on success, 403 on forbidden, 404 if not found, 500 on error
+ */
+export async function PUT(request: NextRequest) {
+  const [error] = validateApiKeyByHeadersWithResult(request.headers);
+  if (error !== null) {
+    return NextResponse.json({ error: error.message }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const federalStateToUpdate = federalStateUpdateSchema.parse(body);
+
+  const encryptedApiKey =
+    federalStateToUpdate.decryptedApiKey != null
+      ? encrypt({
+          text: federalStateToUpdate.decryptedApiKey,
+          plainEncryptionKey: env.encryptionKey,
+        })
+      : null;
+  const existingFederalState = await dbGetFederalStateById(federalStateToUpdate.id);
+  if (existingFederalState === undefined) {
+    return NextResponse.json(
+      { error: `Federal state with id ${federalStateToUpdate.id} does not exist` },
+      { status: 404 },
+    );
+  }
+  const updated = await dbUpdateFederalState({ ...federalStateToUpdate, encryptedApiKey });
+
+  if (updated === undefined) {
+    return NextResponse.json({ error: 'Could not update federal state' }, { status: 500 });
+  }
+
+  return NextResponse.json(updated, { status: 200 });
+}
+
+export async function DELETE(request: NextRequest) {
+  const [error] = validateApiKeyByHeadersWithResult(request.headers);
+  if (error !== null) {
+    return NextResponse.json({ error: error.message }, { status: 403 });
+  }
+
+  let id: string | undefined;
+  try {
+    const body = await request.json();
+    id = body.id;
+  } catch (err) {
+    return NextResponse.json({ error: `Invalid request body ${err}` }, { status: 400 });
+  }
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+  }
+  const existingFederalState = await dbGetFederalStateById(id);
+  if (existingFederalState === undefined) {
+    return NextResponse.json(
+      { error: `Federal state with id ${id} does not exist` },
+      { status: 404 },
+    );
+  }
+
+  const deleted = await dbDeleteFederalState(id);
+  if (!deleted) {
+    return NextResponse.json(
+      { error: `Federal state with id ${id} does not exist` },
+      { status: 404 },
+    );
+  }
+  return NextResponse.json(deleted, { status: 200 });
 }


### PR DESCRIPTION
- Add POST, PUT, and DELETE endpoints for federal state management in the API.
- Introduce validation for existing federal states to prevent duplicates on creation.
- Implement database functions for inserting, updating, and deleting federal states.
- Enhance e2e tests to cover scenarios for creating, updating, and handling duplicate federal states.
- Update existing tests to ensure proper response handling for various states.