### PR TITLE
TD-1084 split click-area of link and buttons

### DIFF
--- a/apps/dialog/src/app/(authed)/(dialog)/characters/character-container.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/characters/character-container.tsx
@@ -67,85 +67,88 @@ export default function CharacterContainer({
   const timeLeft = calculateTimeLeft(character);
 
   return (
-    <Link
-      href={`/characters/editor/${id}`}
-      className="rounded-enterprise-md border p-6 flex items-center gap-4 w-full hover:border-primary"
-    >
-      <figure
-        className="w-11 h-11 bg-light-gray rounded-enterprise-sm flex justify-center items-center"
-        style={{ minWidth: '44px' }}
+    <div className="rounded-enterprise-md border flex items-center w-full hover:border-primary">
+      <Link
+        href={`/characters/editor/${id}`}
+        className="p-6 flex items-center gap-4 flex-1 min-w-0"
       >
-        {maybeSignedPictureUrl ? (
-          <AvatarPicture src={maybeSignedPictureUrl} alt={`${name} Avatar`} variant="small" />
-        ) : (
-          <EmptyImageIcon className="w-4 h-4" />
-        )}
-      </figure>
-      <div className="flex flex-col gap-0 text-left min-w-0">
-        <h2 className={cn('font-medium leading-none min-h-5', truncateClassName)}>{name}</h2>
-        <span className={cn(truncateClassName, 'text-gray-600')}>{description}</span>
-      </div>
-      <div className="grow" />
-      {timeLeft > 0 && character.maxUsageTimeLimit !== null && (
-        <CountDownTimer
-          leftTime={timeLeft}
-          totalTime={character.maxUsageTimeLimit}
-          className="p-1 me-2"
-          stopWatchClassName="w-4 h-4"
-        />
-      )}
-      {userId !== currentUserId && timeLeft <= 0 && (
-        <CreateNewInstanceFromTemplate
-          templateId={id}
-          templatePictureId={character.pictureId ?? undefined}
-          className={'w-8 h-8'}
-          redirectPath="characters"
-          createInstanceCallbackAction={createNewCharacterAction}
-          {...{ title: t('form.copy-page.copy-template'), type: 'button' }}
+        <figure
+          className="w-11 h-11 bg-light-gray rounded-enterprise-sm flex justify-center items-center"
+          style={{ minWidth: '44px' }}
         >
-          <TelliClipboardButton
-            text={t('form.copy-page.copy-template')}
-            className="w-6 h-6"
-            outerDivClassName="p-1 rounded-enterprise-sm"
+          {maybeSignedPictureUrl ? (
+            <AvatarPicture src={maybeSignedPictureUrl} alt={`${name} Avatar`} variant="small" />
+          ) : (
+            <EmptyImageIcon className="w-4 h-4" />
+          )}
+        </figure>
+        <div className="flex flex-col gap-0 text-left min-w-0">
+          <h2 className={cn('font-medium leading-none min-h-5', truncateClassName)}>{name}</h2>
+          <span className={cn(truncateClassName, 'text-gray-600')}>{description}</span>
+        </div>
+      </Link>
+      <div className="flex items-center gap-2 pr-6">
+        {timeLeft > 0 && character.maxUsageTimeLimit !== null && (
+          <CountDownTimer
+            leftTime={timeLeft}
+            totalTime={character.maxUsageTimeLimit}
+            className="p-1 me-2"
+            stopWatchClassName="w-4 h-4"
           />
-        </CreateNewInstanceFromTemplate>
-      )}
+        )}
+        {userId !== currentUserId && timeLeft <= 0 && (
+          <CreateNewInstanceFromTemplate
+            templateId={id}
+            templatePictureId={character.pictureId ?? undefined}
+            className={'w-8 h-8'}
+            redirectPath="characters"
+            createInstanceCallbackAction={createNewCharacterAction}
+            {...{ title: t('form.copy-page.copy-template'), type: 'button' }}
+          >
+            <TelliClipboardButton
+              text={t('form.copy-page.copy-template')}
+              className="w-6 h-6"
+              outerDivClassName="p-1 rounded-enterprise-sm"
+            />
+          </CreateNewInstanceFromTemplate>
+        )}
 
-      {timeLeft > 0 && (
-        <button
-          aria-label={t('shared.share')}
-          onClick={handleNavigateToShare}
-          className={cn(iconClassName)}
-        >
-          <ShareIcon aria-hidden="true" className="min-w-8 min-h-8" />
-          <span className="sr-only">{t('shared.share')}</span>
-        </button>
-      )}
-      {timeLeft < 1 && (
-        <button
-          type="button"
-          aria-label={tCommon('new-chat')}
-          onClick={handleNavigateToNewUnsharedChat}
-          className={cn(iconClassName, 'min-w-8 min-h-8')}
-        >
-          <SharedChatIcon aria-hidden="true" className="min-w-8 min-h-8" />
-          <span className="sr-only">{tCommon('new-chat')}</span>
-        </button>
-      )}
+        {timeLeft > 0 && (
+          <button
+            aria-label={t('shared.share')}
+            onClick={handleNavigateToShare}
+            className={cn(iconClassName)}
+          >
+            <ShareIcon aria-hidden="true" className="min-w-8 min-h-8" />
+            <span className="sr-only">{t('shared.share')}</span>
+          </button>
+        )}
+        {timeLeft < 1 && (
+          <button
+            type="button"
+            aria-label={tCommon('new-chat')}
+            onClick={handleNavigateToNewUnsharedChat}
+            className={cn(iconClassName, 'min-w-8 min-h-8')}
+          >
+            <SharedChatIcon aria-hidden="true" className="min-w-8 min-h-8" />
+            <span className="sr-only">{tCommon('new-chat')}</span>
+          </button>
+        )}
 
-      {currentUserId === userId && character.accessLevel !== 'global' && (
-        <DestructiveActionButton
-          modalTitle={t('form.delete-character')}
-          modalDescription={t('form.character-delete-modal-description')}
-          confirmText={tCommon('delete')}
-          actionFn={handleDeleteCharacter}
-          aria-label={t('form.delete-character')}
-          triggerButtonClassName={cn('border-transparent p-0', iconClassName)}
-        >
-          <TrashIcon aria-hidden="true" className="min-w-8 min-h-8" />
-          <span className="sr-only">{t('form.delete-character')}</span>
-        </DestructiveActionButton>
-      )}
-    </Link>
+        {currentUserId === userId && character.accessLevel !== 'global' && (
+          <DestructiveActionButton
+            modalTitle={t('form.delete-character')}
+            modalDescription={t('form.character-delete-modal-description')}
+            confirmText={tCommon('delete')}
+            actionFn={handleDeleteCharacter}
+            aria-label={t('form.delete-character')}
+            triggerButtonClassName={cn('border-transparent p-0', iconClassName)}
+          >
+            <TrashIcon aria-hidden="true" className="min-w-8 min-h-8" />
+            <span className="sr-only">{t('form.delete-character')}</span>
+          </DestructiveActionButton>
+        )}
+      </div>
+    </div>
   );
 }

--- a/apps/dialog/src/app/(authed)/(dialog)/characters/character-container.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/characters/character-container.tsx
@@ -52,14 +52,6 @@ export default function CharacterContainer({
       toast.error(tToast('delete-toast-error'));
     }
   }
-  function handleNavigateToNewUnsharedChat() {
-    router.push(`/characters/d/${id}`);
-  }
-
-  function handleNavigateToShare() {
-    router.push(`/characters/editor/${id}/share`);
-  }
-
   const timeLeft = calculateTimeLeft(character);
 
   return (
@@ -110,25 +102,24 @@ export default function CharacterContainer({
         )}
 
         {timeLeft > 0 && (
-          <button
+          <Link
             aria-label={t('shared.share')}
-            onClick={handleNavigateToShare}
+            href={`/characters/editor/${id}/share`}
             className={cn(iconClassName)}
           >
             <ShareIcon aria-hidden="true" className="min-w-8 min-h-8" />
             <span className="sr-only">{t('shared.share')}</span>
-          </button>
+          </Link>
         )}
         {timeLeft < 1 && (
-          <button
-            type="button"
+          <Link
             aria-label={tCommon('new-chat')}
-            onClick={handleNavigateToNewUnsharedChat}
+            href={`/characters/d/${id}`}
             className={cn(iconClassName, 'min-w-8 min-h-8')}
           >
             <SharedChatIcon aria-hidden="true" className="min-w-8 min-h-8" />
             <span className="sr-only">{tCommon('new-chat')}</span>
-          </button>
+          </Link>
         )}
 
         {currentUserId === userId && character.accessLevel !== 'global' && (

--- a/apps/dialog/src/app/(authed)/(dialog)/characters/character-container.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/characters/character-container.tsx
@@ -52,15 +52,11 @@ export default function CharacterContainer({
       toast.error(tToast('delete-toast-error'));
     }
   }
-  function handleNavigateToNewUnsharedChat(e: React.MouseEvent<HTMLButtonElement>) {
-    e.preventDefault();
-    e.stopPropagation();
+  function handleNavigateToNewUnsharedChat() {
     router.push(`/characters/d/${id}`);
   }
 
-  function handleNavigateToShare(e: React.MouseEvent<HTMLButtonElement>) {
-    e.preventDefault();
-    e.stopPropagation();
+  function handleNavigateToShare() {
     router.push(`/characters/editor/${id}/share`);
   }
 

--- a/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/learning-scenario-item.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/learning-scenario-item.tsx
@@ -45,9 +45,7 @@ export default function LearningScenarioItem({
     }
   }
 
-  function handleNavigateToShare(e: React.MouseEvent<HTMLButtonElement>) {
-    e.preventDefault();
-    e.stopPropagation();
+  function handleNavigateToShare() {
     router.push(`/learning-scenarios/editor/${learningScenario.id}/share`);
   }
 

--- a/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/learning-scenario-item.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/learning-scenario-item.tsx
@@ -45,10 +45,6 @@ export default function LearningScenarioItem({
     }
   }
 
-  function handleNavigateToShare() {
-    router.push(`/learning-scenarios/editor/${learningScenario.id}/share`);
-  }
-
   async function handleCreateNewLearningScenarioFromTemplate({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     templatePictureId,
@@ -107,14 +103,14 @@ export default function LearningScenarioItem({
           />
         )}
         {timeLeft > 0 && (
-          <button
+          <Link
             aria-label={t('shared.share')}
-            onClick={handleNavigateToShare}
+            href={`/learning-scenarios/editor/${learningScenario.id}/share`}
             className={cn(iconClassName)}
           >
             <ShareIcon aria-hidden="true" className="min-w-8 min-h-8" />
             <span className="sr-only">{t('shared.share')}</span>
-          </button>
+          </Link>
         )}
         {learningScenario.userId !== currentUserId && timeLeft <= 0 && (
           <CreateNewInstanceFromTemplate

--- a/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/learning-scenario-item.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/learning-scenario-item.tsx
@@ -71,80 +71,83 @@ export default function LearningScenarioItem({
   const timeLeft = calculateTimeLeft(learningScenario);
 
   return (
-    <Link
-      href={`/learning-scenarios/editor/${learningScenario.id}`}
-      className="rounded-enterprise-md border p-6 flex items-center gap-4 w-full hover:border-primary"
-    >
-      <figure
-        className="w-11 h-11 bg-light-gray rounded-enterprise-sm flex justify-center items-center"
-        style={{ minWidth: '44px' }}
+    <div className="rounded-enterprise-md border flex items-center w-full hover:border-primary">
+      <Link
+        href={`/learning-scenarios/editor/${learningScenario.id}`}
+        className="p-6 flex items-center gap-4 flex-1 min-w-0"
       >
-        {learningScenario.maybeSignedPictureUrl ? (
-          <AvatarPicture
-            src={learningScenario.maybeSignedPictureUrl}
-            alt={`${learningScenario.name} Avatar`}
-            variant="small"
+        <figure
+          className="w-11 h-11 bg-light-gray rounded-enterprise-sm flex justify-center items-center"
+          style={{ minWidth: '44px' }}
+        >
+          {learningScenario.maybeSignedPictureUrl ? (
+            <AvatarPicture
+              src={learningScenario.maybeSignedPictureUrl}
+              alt={`${learningScenario.name} Avatar`}
+              variant="small"
+            />
+          ) : (
+            <EmptyImageIcon className="w-4 h-4" />
+          )}
+        </figure>
+        <div className="flex flex-col gap-1 text-left min-w-0">
+          <h2 className={cn('font-medium leading-none', truncateClassName)}>
+            {learningScenario.name}
+          </h2>
+          <span className={cn('text-gray-600', truncateClassName)}>
+            {learningScenario.description}
+          </span>
+        </div>
+      </Link>
+      <div className="flex items-center gap-2 pr-6">
+        {learningScenario.startedAt !== null && timeLeft > 0 && (
+          <CountDownTimer
+            className="p-1 me-2"
+            leftTime={timeLeft}
+            totalTime={learningScenario.maxUsageTimeLimit ?? 0}
+            stopWatchClassName="w-4 h-4"
           />
-        ) : (
-          <EmptyImageIcon className="w-4 h-4" />
         )}
-      </figure>
-      <div className="flex flex-col gap-1 text-left min-w-0">
-        <h2 className={cn('font-medium leading-none', truncateClassName)}>
-          {learningScenario.name}
-        </h2>
-        <span className={cn('text-gray-600', truncateClassName)}>
-          {learningScenario.description}
-        </span>
+        {timeLeft > 0 && (
+          <button
+            aria-label={t('shared.share')}
+            onClick={handleNavigateToShare}
+            className={cn(iconClassName)}
+          >
+            <ShareIcon aria-hidden="true" className="min-w-8 min-h-8" />
+            <span className="sr-only">{t('shared.share')}</span>
+          </button>
+        )}
+        {learningScenario.userId !== currentUserId && timeLeft <= 0 && (
+          <CreateNewInstanceFromTemplate
+            redirectPath="learning-scenarios"
+            createInstanceCallbackAction={handleCreateNewLearningScenarioFromTemplate}
+            templateId={learningScenario.id}
+            templatePictureId={learningScenario.pictureId ?? undefined}
+            className="w-8 h-8 flex items-center justify-center"
+            {...{ title: t('form.copy-page.copy-template'), type: 'button' }}
+          >
+            <TelliClipboardButton
+              text={t('form.copy-page.copy-template')}
+              className="w-6 h-6"
+              outerDivClassName="p-1 rounded-enterprise-sm"
+            />
+          </CreateNewInstanceFromTemplate>
+        )}
+        {currentUserId === learningScenario.userId && (
+          <DestructiveActionButton
+            aria-label={tCommon('delete')}
+            modalDescription={t('form.delete-description')}
+            modalTitle={t('form.delete-title')}
+            confirmText={tCommon('delete')}
+            actionFn={handleDeleteLearningScenario}
+            triggerButtonClassName={cn('border-transparent p-0', iconClassName)}
+          >
+            <TrashIcon aria-hidden="true" className="w-8 h-8" />
+            <span className="sr-only">{tCommon('delete')}</span>
+          </DestructiveActionButton>
+        )}
       </div>
-      <div className="grow" />
-      {learningScenario.startedAt !== null && timeLeft > 0 && (
-        <CountDownTimer
-          className="p-1 me-2"
-          leftTime={timeLeft}
-          totalTime={learningScenario.maxUsageTimeLimit ?? 0}
-          stopWatchClassName="w-4 h-4"
-        />
-      )}
-      {timeLeft > 0 && (
-        <button
-          aria-label={t('shared.share')}
-          onClick={handleNavigateToShare}
-          className={cn(iconClassName)}
-        >
-          <ShareIcon aria-hidden="true" className="min-w-8 min-h-8" />
-          <span className="sr-only">{t('shared.share')}</span>
-        </button>
-      )}
-      {learningScenario.userId !== currentUserId && timeLeft <= 0 && (
-        <CreateNewInstanceFromTemplate
-          redirectPath="learning-scenarios"
-          createInstanceCallbackAction={handleCreateNewLearningScenarioFromTemplate}
-          templateId={learningScenario.id}
-          templatePictureId={learningScenario.pictureId ?? undefined}
-          className="w-8 h-8 flex items-center justify-center"
-          {...{ title: t('form.copy-page.copy-template'), type: 'button' }}
-        >
-          <TelliClipboardButton
-            text={t('form.copy-page.copy-template')}
-            className="w-6 h-6"
-            outerDivClassName="p-1 rounded-enterprise-sm"
-          />
-        </CreateNewInstanceFromTemplate>
-      )}
-      {currentUserId === learningScenario.userId && (
-        <DestructiveActionButton
-          aria-label={tCommon('delete')}
-          modalDescription={t('form.delete-description')}
-          modalTitle={t('form.delete-title')}
-          confirmText={tCommon('delete')}
-          actionFn={handleDeleteLearningScenario}
-          triggerButtonClassName={cn('border-transparent p-0', iconClassName)}
-        >
-          <TrashIcon aria-hidden="true" className="w-8 h-8" />
-          <span className="sr-only">{tCommon('delete')}</span>
-        </DestructiveActionButton>
-      )}
-    </Link>
+    </div>
   );
 }


### PR DESCRIPTION
Clicking the delete icon would navigate to the edit page of the character / learning scenario.
`preventDefault()` on the delete icon can no longer be used, as the radix-ui AlertDialog depends on the unhandled event.

**Solution**: only the area around avatar, name and description contains the link for navigation to the edit view

<img width="787" height="106" alt="image" src="https://github.com/user-attachments/assets/e5adb26a-7cd2-4f81-88e2-e45c7823e93c" />
