### PR TITLE
ci: remove pnpm audit from pipeline

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,24 +31,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-  check_audit:
-    runs-on: ubuntu-latest
-    needs: install
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Audit dependencies
-        run: pnpm audit --audit-level=critical
-
   check_formatting:
     runs-on: ubuntu-latest
     needs: install


### PR DESCRIPTION
dependabot is used for vulnerability and dependency management. The separate build step is not needed.