### PR TITLE
TD-1110 add basic accessibility e2e test

### DIFF
--- a/apps/dialog/e2e/load_test/common.ts
+++ b/apps/dialog/e2e/load_test/common.ts
@@ -130,7 +130,7 @@ export async function performLogin(
     });
 
     if (!idpHint) {
-      await page.getByRole('button', { name: 'Mit VIDIS einloggen' }).click();
+      await page.getByTestId('vidis-login-button').click();
     }
 
     const usernameInput = page.getByLabel('Username');

--- a/apps/dialog/e2e/tests/accessibility.test.ts
+++ b/apps/dialog/e2e/tests/accessibility.test.ts
@@ -1,0 +1,49 @@
+import { expect, type Page, test, type TestInfo } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { AUTH_FILES } from '../utils/const';
+import { waitForChatHistory } from '../utils/utils';
+
+async function expectNoAccessibilityViolations(page: Page, testInfo: TestInfo) {
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    // Enable all WCAG 2.0 and 2.1 rules tagged as A and AA.
+    // Both 2.0 and 2.1 must be included to cover all relevant rules.
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    // Disable rules, which cannot be fixed now.
+    .disableRules(['color-contrast'])
+    .analyze();
+
+  expect(accessibilityScanResults.violations).toEqual([]);
+}
+
+test.describe('accessibility checks', () => {
+  test.describe('unauthenticated', () => {
+    test('login page has no critical or serious axe violations', async ({ page }, testInfo) => {
+      await page.goto('/login');
+      await page.getByRole('button', { name: 'Mit VIDIS einloggen' }).waitFor();
+
+      await expectNoAccessibilityViolations(page, testInfo);
+    });
+  });
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_FILES.teacher });
+
+    [
+      '/',
+      '/image-generation',
+      '/assistants',
+      '/learning-scenarios',
+      '/characters',
+      '/top-up',
+    ].forEach((url) => {
+      test(`page "${url}" has no critical or serious axe violations`, async ({
+        page,
+      }, testInfo) => {
+        await page.goto(url);
+        await waitForChatHistory(page);
+
+        await expectNoAccessibilityViolations(page, testInfo);
+      });
+    });
+  });
+});

--- a/apps/dialog/e2e/tests/accessibility.test.ts
+++ b/apps/dialog/e2e/tests/accessibility.test.ts
@@ -19,7 +19,7 @@ test.describe('accessibility checks', () => {
   test.describe('unauthenticated', () => {
     test('login page has no axe violations', async ({ page }) => {
       await page.goto('/login');
-      await page.getByRole('button', { name: 'Mit VIDIS einloggen' }).waitFor();
+      await page.getByTestId('vidis-login-button').waitFor();
 
       await expectNoAccessibilityViolations(page);
     });

--- a/apps/dialog/e2e/tests/accessibility.test.ts
+++ b/apps/dialog/e2e/tests/accessibility.test.ts
@@ -1,9 +1,9 @@
-import { expect, type Page, test, type TestInfo } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { AUTH_FILES } from '../utils/const';
 import { waitForChatHistory } from '../utils/utils';
 
-async function expectNoAccessibilityViolations(page: Page, testInfo: TestInfo) {
+async function expectNoAccessibilityViolations(page: Page) {
   const accessibilityScanResults = await new AxeBuilder({ page })
     // Enable all WCAG 2.0 and 2.1 rules tagged as A and AA.
     // Both 2.0 and 2.1 must be included to cover all relevant rules.
@@ -17,11 +17,11 @@ async function expectNoAccessibilityViolations(page: Page, testInfo: TestInfo) {
 
 test.describe('accessibility checks', () => {
   test.describe('unauthenticated', () => {
-    test('login page has no critical or serious axe violations', async ({ page }, testInfo) => {
+    test('login page has no axe violations', async ({ page }) => {
       await page.goto('/login');
       await page.getByRole('button', { name: 'Mit VIDIS einloggen' }).waitFor();
 
-      await expectNoAccessibilityViolations(page, testInfo);
+      await expectNoAccessibilityViolations(page);
     });
   });
 
@@ -36,13 +36,11 @@ test.describe('accessibility checks', () => {
       '/characters',
       '/top-up',
     ].forEach((url) => {
-      test(`page "${url}" has no critical or serious axe violations`, async ({
-        page,
-      }, testInfo) => {
+      test(`page "${url}" has no axe violations`, async ({ page }) => {
         await page.goto(url);
         await waitForChatHistory(page);
 
-        await expectNoAccessibilityViolations(page, testInfo);
+        await expectNoAccessibilityViolations(page);
       });
     });
   });

--- a/apps/dialog/e2e/tests/assistant/assistant-file-upload.test.ts
+++ b/apps/dialog/e2e/tests/assistant/assistant-file-upload.test.ts
@@ -11,9 +11,12 @@ test('should upload file and chat with assistant template (Schulorganisationsass
   await page.waitForURL('/assistants');
 
   // Wait for the Schulorganisationsassistent template card and click the chat button
-  const card = page.getByRole('button', { name: 'Schulorganisationsassistent' }).first();
+  const card = page
+    .getByTestId('entity-card')
+    .filter({ hasText: 'Schulorganisationsassistent' })
+    .first();
   await expect(card).toBeVisible();
-  await card.getByRole('button', { name: 'Neuer Chat' }).click();
+  await card.getByTestId('chat-button').click();
 
   // Wait for the assistant chat page to load
   await page.waitForURL('/assistants/d/**');
@@ -26,7 +29,7 @@ test('should upload file and chat with assistant template (Schulorganisationsass
   await expect(page.locator('form').getByRole('img').nth(1)).toBeVisible();
 
   // Send message about file contents
-  await sendMessage(page, 'Wie heißt die Hauptperson die in dieser Datei genannnt wird?');
+  await sendMessage(page, 'Wie heißt die Hauptperson die in dieser Datei genannt wird?');
 
   // Verify the response contains expected content
   const assistantMessage = page.getByLabel('assistant message 1');

--- a/apps/dialog/e2e/tests/assistant/create-assistant-from-template.test.ts
+++ b/apps/dialog/e2e/tests/assistant/create-assistant-from-template.test.ts
@@ -7,10 +7,11 @@ test('create assistant from template', async ({ page }) => {
   await page.goto('/assistants');
 
   const card = page
-    .getByRole('button', { name: 'Schulorganisationsassistent', exact: true })
+    .getByTestId('entity-card')
+    .filter({ hasText: 'Schulorganisationsassistent' })
     .first();
   await expect(card).toBeVisible({ timeout: 15000 });
-  await card.click();
+  await card.getByTestId('entity-link').click();
   await page.waitForURL('/assistants/**');
 
   const copyButton = page.getByTestId('custom-chat-duplicate-button').first();

--- a/apps/dialog/e2e/tests/assistant/create-assistant.test.ts
+++ b/apps/dialog/e2e/tests/assistant/create-assistant.test.ts
@@ -22,6 +22,7 @@ test('teacher can login, create an assistant and start a chat', async ({ page })
   await page.getByTestId('assistant-name-input').click();
   await page.getByTestId('assistant-name-input').fill(assistantName);
   await page.getByTestId('assistant-name-input').press('Tab');
+  await waitForAutosave(page);
   await page
     .getByTestId('assistant-description-input')
     .fill('Hilft bei der Planung und Budget Rechnung beim Bau eines Einfamilienhauses');
@@ -97,17 +98,24 @@ test('data is autosaved on blur', async ({ page }) => {
   await page.getByTestId('assistant-name-input').click();
   await page.getByTestId('assistant-name-input').fill('Autosave Test GPT');
   await page.getByTestId('assistant-name-input').press('Tab');
+  await waitForAutosave(page);
 
   await page
     .getByTestId('assistant-description-input')
     .fill('Test description for autosave validation');
+  await page.getByTestId('assistant-description-input').press('Tab');
+  await waitForAutosave(page);
 
   await page
     .getByTestId('assistant-instructions-input')
     .fill('Test functions for autosave validation');
+  await page.getByTestId('assistant-instructions-input').press('Tab');
+  await waitForAutosave(page);
 
   // Add a prompt suggestion
   await page.getByTestId('prompt-suggestion-1-input').fill('Test prompt suggestion');
+  await page.getByTestId('prompt-suggestion-1-input').press('Tab');
+  await waitForAutosave(page);
 
   // Save the form
   await page.getByTestId('custom-chat-save-button').first().click();
@@ -124,35 +132,37 @@ test('data is autosaved on blur', async ({ page }) => {
   await page.waitForURL('/assistants/editor/**');
 
   // change title to new value
+  await page.getByTestId('assistant-name-input').fill('');
   await page.getByTestId('assistant-name-input').fill('New Title');
   await page.getByTestId('assistant-name-input').press('Tab');
+  await waitForAutosave(page);
   await page.reload();
   await expect(page.getByTestId('assistant-name-input')).toHaveValue('New Title');
 
   // change description to new value
   const descriptionInput = page.getByTestId('assistant-description-input');
-  await descriptionInput.click();
-  await descriptionInput.press('ControlOrMeta+A');
+  await descriptionInput.fill('');
   await descriptionInput.fill('New Description');
   await descriptionInput.press('Tab');
+  await waitForAutosave(page);
   await page.reload();
   await expect(page.getByTestId('assistant-description-input')).toHaveValue('New Description');
 
   // change instructions to new value
   const instructionsInput = page.getByTestId('assistant-instructions-input');
-  await instructionsInput.click();
-  await instructionsInput.press('ControlOrMeta+A');
+  await instructionsInput.fill('');
   await instructionsInput.fill('New Instructions');
   await instructionsInput.press('Tab');
+  await waitForAutosave(page);
   await page.reload();
   await expect(page.getByTestId('assistant-instructions-input')).toHaveValue('New Instructions');
 
   // change prompt suggestion to new value
   const promptSuggestionInput = page.getByTestId('prompt-suggestion-1-input');
-  await promptSuggestionInput.click();
-  await promptSuggestionInput.press('ControlOrMeta+A');
+  await promptSuggestionInput.fill('');
   await promptSuggestionInput.fill('New Prompt Suggestion');
   await promptSuggestionInput.press('Tab');
+  await waitForAutosave(page);
   await page.reload();
   await expect(page.getByTestId('prompt-suggestion-1-input')).toHaveValue('New Prompt Suggestion');
 });

--- a/apps/dialog/e2e/tests/assistant/create-assistant.test.ts
+++ b/apps/dialog/e2e/tests/assistant/create-assistant.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
-import { waitForToast } from '../../utils/utils';
+import { waitForAutosave, waitForToast } from '../../utils/utils';
 import { sendMessage, uploadFile } from '../../utils/chat';
 import { deleteAssistant } from '../../utils/assistant';
 
@@ -48,11 +48,12 @@ test('teacher can login, create an assistant and start a chat', async ({ page })
 
   // save form
   await page.getByTestId('custom-chat-save-button').first().click();
+  await waitForAutosave(page);
   await page.goto('/assistants');
 
-  const card = page.getByRole('button', { name: assistantName }).first();
+  const card = page.getByTestId('entity-card').filter({ hasText: assistantName }).first();
   await expect(card).toBeVisible({ timeout: 15000 });
-  await card.getByRole('button', { name: 'Neuer Chat' }).click();
+  await card.getByTestId('chat-button').click();
   await page.waitForURL('/assistants/d/**');
   await expect(page.getByRole('heading')).toContainText(assistantName);
   await expect(page.locator('body')).toContainText(
@@ -110,12 +111,16 @@ test('data is autosaved on blur', async ({ page }) => {
 
   // Save the form
   await page.getByTestId('custom-chat-save-button').first().click();
+  await waitForAutosave(page);
 
   // Navigate to assistant overview explicitly to check if data was saved correctly
   await page.goto('/assistants');
-  const autosaveCard = page.getByRole('button', { name: 'Autosave Test GPT' }).first();
+  const autosaveCard = page
+    .getByTestId('entity-card')
+    .filter({ hasText: 'Autosave Test GPT' })
+    .first();
   await expect(autosaveCard).toBeVisible({ timeout: 15000 });
-  await autosaveCard.click();
+  await autosaveCard.getByTestId('entity-link').click();
   await page.waitForURL('/assistants/editor/**');
 
   // change title to new value

--- a/apps/dialog/e2e/tests/character/create-character-from-template.test.ts
+++ b/apps/dialog/e2e/tests/character/create-character-from-template.test.ts
@@ -8,13 +8,14 @@ test('create character from template', async ({ page }) => {
   await page.goto('/characters');
 
   const card = page
-    .getByRole('button', { name: 'Johann Wolfgang von Goethe', exact: true })
+    .getByTestId('entity-card')
+    .filter({ hasText: 'Johann Wolfgang von Goethe' })
     .first();
   await expect(card).toBeVisible();
-  await card.click();
+  await card.getByTestId('entity-link').click();
   await page.waitForURL('/characters/**');
 
-  const copyButton = page.getByTestId('custom-chat-duplicate-button');
+  const copyButton = page.getByTestId('custom-chat-duplicate-button').first();
   await expect(copyButton).toBeVisible();
   await expect(copyButton).toBeEnabled();
   await copyButton.click();

--- a/apps/dialog/e2e/tests/generic-chat/model-selection.test.ts
+++ b/apps/dialog/e2e/tests/generic-chat/model-selection.test.ts
@@ -24,7 +24,7 @@ test('Starting a new chat clears the prompt and resets the page when already on 
   await page.getByPlaceholder('Wie kann ich Dir helfen?').fill(prompt);
 
   // Start a new chat when already on the home page (/)
-  await page.getByText('Neuer Chat').click();
+  await page.getByLabel('Hauptnavigation').getByText('Neuer Chat').click();
 
   // The prompt should be gone after the page resets
   await expect(page.getByPlaceholder('Wie kann ich Dir helfen?')).toHaveValue('');

--- a/apps/dialog/e2e/tests/learning-scenarios/create-learning-scenario-from-template.test.ts
+++ b/apps/dialog/e2e/tests/learning-scenarios/create-learning-scenario-from-template.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
+import { waitForAutosave } from '../../utils/utils';
 import { nanoid } from 'nanoid';
 
 test.use({ storageState: AUTH_FILES.teacher });
@@ -7,13 +8,13 @@ test.use({ storageState: AUTH_FILES.teacher });
 test('create learning scenario from template', async ({ page }) => {
   await page.goto('/learning-scenarios');
 
-  const card = page.getByRole('button', { name: 'Lern was über KI' }).first();
+  const card = page.getByTestId('entity-card').filter({ hasText: 'Lern was über KI' }).first();
   await expect(card).toBeVisible();
-  await card.click();
+  await card.getByTestId('entity-link').click();
   // Non-owned scenarios now route to read-only view instead of editor
   await page.waitForURL('/learning-scenarios/**');
 
-  const duplicateButton = page.getByRole('button', { name: 'Duplizieren' });
+  const duplicateButton = page.getByRole('button', { name: 'Duplizieren' }).first();
   await expect(duplicateButton).toBeVisible();
   await expect(duplicateButton).toBeEnabled();
   await duplicateButton.click();
@@ -29,8 +30,7 @@ test('create learning scenario from template', async ({ page }) => {
   await page.getByRole('textbox', { name: 'Arbeitsauftrag' }).fill('Arbeitsauftrag');
 
   // Wait for autosave to complete
-  await page.waitForTimeout(500);
-  await expect(page.getByText('Gespeichert').first()).toBeVisible({ timeout: 5000 });
+  await waitForAutosave(page);
 
   // Navigate back to learning scenarios list to verify creation
   await page.goto('/learning-scenarios');

--- a/apps/dialog/e2e/tests/learning-scenarios/create-learning-scenario-from-template.test.ts
+++ b/apps/dialog/e2e/tests/learning-scenarios/create-learning-scenario-from-template.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
 import { waitForAutosave } from '../../utils/utils';
 import { nanoid } from 'nanoid';
+import { configureLearningScenario } from '../../utils/learning-scenario';
 
 test.use({ storageState: AUTH_FILES.teacher });
 
@@ -22,12 +23,14 @@ test('create learning scenario from template', async ({ page }) => {
   await page.waitForURL('/learning-scenarios/editor/**');
 
   const name = 'Kopiertes Lernszenario ' + nanoid(8);
-  await page.getByRole('textbox', { name: 'Name des Lernszenarios' }).fill(name);
 
   // Fill in other required fields (the new form auto-saves)
-  await page.getByRole('textbox', { name: 'Kurzbeschreibung' }).fill('Beschreibung');
-  await page.getByRole('textbox', { name: 'Instruktionen' }).fill('Instruktionen');
-  await page.getByRole('textbox', { name: 'Arbeitsauftrag' }).fill('Arbeitsauftrag');
+  await configureLearningScenario(page, {
+    name,
+    description: 'Beschreibung',
+    additionalInstructions: 'Instruktionen',
+    studentExercise: 'Arbeitsauftrag',
+  });
 
   // Wait for autosave to complete
   await waitForAutosave(page);

--- a/apps/dialog/e2e/tests/learning-scenarios/create-learning-scenario.test.ts
+++ b/apps/dialog/e2e/tests/learning-scenarios/create-learning-scenario.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
-import { waitForToast, waitForToastDisappear } from '../../utils/utils';
+import { waitForAutosave, waitForToast, waitForToastDisappear } from '../../utils/utils';
 import { sendMessage } from '../../utils/chat';
 import {
   configureLearningScenario,
@@ -159,9 +159,9 @@ test('data is autosaved on blur', async ({ page }) => {
   // Navigate back to list and then click to open for editing
   await page.goto('/learning-scenarios');
   await page.waitForURL('/learning-scenarios');
-  const listItem = page.getByRole('button', { name });
+  const listItem = page.getByTestId('entity-card').filter({ hasText: name }).first();
   await expect(listItem).toBeVisible();
-  await listItem.click();
+  await listItem.getByTestId('entity-link').click();
   await page.waitForURL('/learning-scenarios/**');
   await waitForToastDisappear(page); // wait for success toast to disappear before continuing
 
@@ -169,8 +169,7 @@ test('data is autosaved on blur', async ({ page }) => {
   // Title
   await page.getByRole('textbox', { name: 'Name des Lernszenarios' }).fill('New Title');
   await page.getByRole('textbox', { name: 'Name des Lernszenarios' }).press('Tab');
-  await page.waitForTimeout(300);
-  await expect(page.getByText('Gespeichert').first()).toBeVisible({ timeout: 5000 });
+  await waitForAutosave(page);
   await page.reload();
   await expect(page.getByRole('textbox', { name: 'Name des Lernszenarios' })).toHaveValue(
     'New Title',
@@ -179,8 +178,7 @@ test('data is autosaved on blur', async ({ page }) => {
   // Description
   await page.getByRole('textbox', { name: 'Kurzbeschreibung' }).fill('New Description');
   await page.getByRole('textbox', { name: 'Kurzbeschreibung' }).press('Tab');
-  await page.waitForTimeout(300);
-  await expect(page.getByText('Gespeichert').first()).toBeVisible({ timeout: 5000 });
+  await waitForAutosave(page);
   await page.reload();
   await expect(page.getByRole('textbox', { name: 'Kurzbeschreibung' })).toHaveValue(
     'New Description',
@@ -189,8 +187,7 @@ test('data is autosaved on blur', async ({ page }) => {
   // Instructions
   await page.getByRole('textbox', { name: 'Instruktionen' }).fill('New Instructions');
   await page.getByRole('textbox', { name: 'Instruktionen' }).press('Tab');
-  await page.waitForTimeout(300);
-  await expect(page.getByText('Gespeichert').first()).toBeVisible({ timeout: 5000 });
+  await waitForAutosave(page);
   await page.reload();
   await expect(page.getByRole('textbox', { name: 'Instruktionen' })).toHaveValue(
     'New Instructions',
@@ -199,8 +196,7 @@ test('data is autosaved on blur', async ({ page }) => {
   // Student Exercise
   await page.getByRole('textbox', { name: 'Arbeitsauftrag' }).fill('New Exercise');
   await page.getByRole('textbox', { name: 'Arbeitsauftrag' }).press('Tab');
-  await page.waitForTimeout(300);
-  await expect(page.getByText('Gespeichert').first()).toBeVisible({ timeout: 5000 });
+  await waitForAutosave(page);
   await page.reload();
   await expect(page.getByRole('textbox', { name: 'Arbeitsauftrag' })).toHaveValue('New Exercise');
 

--- a/apps/dialog/e2e/tests/learning-scenarios/create-learning-scenario.test.ts
+++ b/apps/dialog/e2e/tests/learning-scenarios/create-learning-scenario.test.ts
@@ -167,6 +167,7 @@ test('data is autosaved on blur', async ({ page }) => {
 
   // Edit and verify autosave for each field
   // Title
+  await page.getByRole('textbox', { name: 'Name des Lernszenarios' }).fill('');
   await page.getByRole('textbox', { name: 'Name des Lernszenarios' }).fill('New Title');
   await page.getByRole('textbox', { name: 'Name des Lernszenarios' }).press('Tab');
   await waitForAutosave(page);
@@ -176,6 +177,7 @@ test('data is autosaved on blur', async ({ page }) => {
   );
 
   // Description
+  await page.getByRole('textbox', { name: 'Kurzbeschreibung' }).fill('');
   await page.getByRole('textbox', { name: 'Kurzbeschreibung' }).fill('New Description');
   await page.getByRole('textbox', { name: 'Kurzbeschreibung' }).press('Tab');
   await waitForAutosave(page);
@@ -185,6 +187,7 @@ test('data is autosaved on blur', async ({ page }) => {
   );
 
   // Instructions
+  await page.getByRole('textbox', { name: 'Instruktionen' }).fill('');
   await page.getByRole('textbox', { name: 'Instruktionen' }).fill('New Instructions');
   await page.getByRole('textbox', { name: 'Instruktionen' }).press('Tab');
   await waitForAutosave(page);
@@ -194,6 +197,7 @@ test('data is autosaved on blur', async ({ page }) => {
   );
 
   // Student Exercise
+  await page.getByRole('textbox', { name: 'Arbeitsauftrag' }).fill('');
   await page.getByRole('textbox', { name: 'Arbeitsauftrag' }).fill('New Exercise');
   await page.getByRole('textbox', { name: 'Arbeitsauftrag' }).press('Tab');
   await waitForAutosave(page);

--- a/apps/dialog/e2e/tests/learning-scenarios/use-of-web-sources.test.ts
+++ b/apps/dialog/e2e/tests/learning-scenarios/use-of-web-sources.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
 import { sendMessage } from '../../utils/chat';
 import { configureLearningScenario } from '../../utils/learning-scenario';
+import { waitForAutosave } from '../../utils/utils';
 
 test.use({ storageState: AUTH_FILES.teacher });
 
@@ -35,7 +36,7 @@ test('teacher can create shared chat with web sources, student can join chat and
   await page.getByRole('button', { name: 'Webseite hinzufügen' }).click();
 
   // Still on the editor page after autosave
-  await page.waitForTimeout(2000);
+  await waitForAutosave(page);
   const stopSharingButton = page.getByRole('button', { name: 'Stop' });
   if (await stopSharingButton.isVisible()) {
     await stopSharingButton.click();

--- a/apps/dialog/e2e/tests/template-elements-visible.test.ts
+++ b/apps/dialog/e2e/tests/template-elements-visible.test.ts
@@ -13,7 +13,8 @@ test('all predefined characters are visible for everyone', async ({ page }) => {
   await page.waitForURL('/characters**');
 
   for (const elementIdentifier of templateCharactersIdentifier) {
-    await expect(page.getByRole('button', { name: elementIdentifier }).first()).toBeVisible();
+    const card = page.getByTestId('entity-card').filter({ hasText: elementIdentifier }).first();
+    await expect(card).toBeVisible();
   }
 });
 
@@ -23,7 +24,8 @@ test('all predefined assistants are visible for everyone', async ({ page }) => {
   await page.waitForURL('/assistants**');
 
   for (const elementIdentifier of templateAssistantsIdentifier) {
-    await expect(page.getByRole('button', { name: elementIdentifier }).first()).toBeVisible();
+    const card = page.getByTestId('entity-card').filter({ hasText: elementIdentifier }).first();
+    await expect(card).toBeVisible();
   }
 });
 
@@ -33,6 +35,7 @@ test('all predefined learning scenarios are visible for everyone', async ({ page
   await page.waitForURL('/learning-scenarios**');
 
   for (const elementIdentifier of templateLearningScenariosIdentifier) {
-    await expect(page.getByRole('button', { name: elementIdentifier }).first()).toBeVisible();
+    const card = page.getByTestId('entity-card').filter({ hasText: elementIdentifier }).first();
+    await expect(card).toBeVisible();
   }
 });

--- a/apps/dialog/e2e/utils/assistant.ts
+++ b/apps/dialog/e2e/utils/assistant.ts
@@ -1,9 +1,9 @@
 import { expect, Page } from '@playwright/test';
 
 export async function deleteAssistant(page: Page, name: string) {
-  const card = page.getByRole('button', { name }).first();
+  const card = page.getByTestId('entity-card').filter({ hasText: name }).first();
   await expect(card).toBeVisible({ timeout: 15000 });
-  await card.click();
+  await card.getByTestId('entity-link').click();
   await page.waitForURL('/assistants/editor/**');
   const deleteButton = page.getByTestId('custom-chat-delete-button').first();
   await expect(deleteButton).toBeVisible();

--- a/apps/dialog/e2e/utils/character.ts
+++ b/apps/dialog/e2e/utils/character.ts
@@ -1,9 +1,10 @@
 import { expect, Page } from '@playwright/test';
+import { waitForAutosave } from './utils';
 
 export async function deleteCharacter(page: Page, name: string) {
-  const card = page.getByRole('button', { name }).first();
-  await expect(card).toBeVisible();
-  await card.click();
+  const card = page.getByTestId('entity-card').filter({ hasText: name }).first();
+  await expect(card).toBeVisible({ timeout: 15000 });
+  await card.getByTestId('entity-link').click();
   await page.waitForURL('/characters/editor/**');
   const deleteButton = page.getByTestId('custom-chat-delete-button').first();
   await expect(deleteButton).toBeVisible();
@@ -39,6 +40,5 @@ export async function configureCharacter(
     .getByTestId('character-instructions-input')
     .fill(data?.instructions ?? 'John Cena soll über seine Karriere und Erfolge sprechen.');
 
-  await page.waitForTimeout(500);
-  await expect(page.getByText('Gespeichert').first()).toBeVisible({ timeout: 5000 });
+  await waitForAutosave(page);
 }

--- a/apps/dialog/e2e/utils/character.ts
+++ b/apps/dialog/e2e/utils/character.ts
@@ -21,6 +21,8 @@ export async function configureCharacter(
   },
 ) {
   await page.getByTestId('character-name-input').fill(data?.name ?? 'John Cena');
+  await page.getByTestId('character-name-input').press('Tab');
+  await waitForAutosave(page);
 
   await page
     .getByTestId('character-description-input')
@@ -28,6 +30,8 @@ export async function configureCharacter(
       data?.description ??
         'Er ist bekannt für seinen Spruch „You can`t see me“ und seine Wrestling-Karriere.',
     );
+  await page.getByTestId('character-description-input').press('Tab');
+  await waitForAutosave(page);
 
   await page
     .getByTestId('character-initial-message-input')
@@ -35,11 +39,12 @@ export async function configureCharacter(
       data?.initialMessage ??
         'Hallo, ich bin John Cena! Was möchtest du über Wrestling oder meine Karriere wissen?',
     );
+  await page.getByTestId('character-initial-message-input').press('Tab');
+  await waitForAutosave(page);
 
   await page
     .getByTestId('character-instructions-input')
     .fill(data?.instructions ?? 'John Cena soll über seine Karriere und Erfolge sprechen.');
-
-  await page.getByTestId('custom-chat-save-button').first().click();
+  await page.getByTestId('character-instructions-input').press('Tab');
   await waitForAutosave(page);
 }

--- a/apps/dialog/e2e/utils/character.ts
+++ b/apps/dialog/e2e/utils/character.ts
@@ -40,5 +40,6 @@ export async function configureCharacter(
     .getByTestId('character-instructions-input')
     .fill(data?.instructions ?? 'John Cena soll über seine Karriere und Erfolge sprechen.');
 
+  await page.getByTestId('custom-chat-save-button').first().click();
   await waitForAutosave(page);
 }

--- a/apps/dialog/e2e/utils/learning-scenario.ts
+++ b/apps/dialog/e2e/utils/learning-scenario.ts
@@ -1,4 +1,5 @@
 import { expect, Page } from '@playwright/test';
+import { waitForAutosave } from './utils';
 
 export async function createLearningScenario(page: Page) {
   await page.goto('/learning-scenarios');
@@ -14,9 +15,9 @@ async function confirmDelete(page: Page) {
 }
 
 export async function deleteLearningScenario(page: Page, name: string) {
-  const card = page.getByRole('button', { name }).first();
-  await expect(card).toBeVisible();
-  await card.click();
+  const card = page.getByTestId('entity-card').filter({ hasText: name }).first();
+  await expect(card).toBeVisible({ timeout: 15000 });
+  await card.getByTestId('entity-link').click();
   await page.waitForURL('/learning-scenarios/editor/**');
   const deleteButton = page.getByTestId('custom-chat-delete-button').first();
   await expect(deleteButton).toBeVisible();
@@ -73,6 +74,5 @@ export async function configureLearningScenario(
     );
 
   // Wait for autosave to complete (triggered by blur on last field)
-  await page.waitForTimeout(500);
-  await expect(page.getByText('Gespeichert').first()).toBeVisible({ timeout: 5000 });
+  await waitForAutosave(page);
 }

--- a/apps/dialog/e2e/utils/learning-scenario.ts
+++ b/apps/dialog/e2e/utils/learning-scenario.ts
@@ -44,14 +44,15 @@ export async function configureLearningScenario(
     additionalInstructions?: string;
   },
 ) {
-  // Fill name field
+  // Fill name field and blur for auto-save
   await page
-    .getByRole('textbox', { name: 'Name des Lernszenarios' })
+    .getByTestId('learning-scenario-name-input')
     .fill(data?.name ?? 'Absolutismus unter Ludwig XIV – Gruppe 1 Soldaten');
+  await page.getByTestId('learning-scenario-name-input').press('Tab');
 
   // Fill description field
   await page
-    .getByRole('textbox', { name: 'Kurzbeschreibung' })
+    .getByTestId('learning-scenario-description-input')
     .fill(data?.description ?? 'Zwischen Absolutismus und Demokratie (Ludwig XIV)');
 
   // Note: schoolType, gradeLevel, and subject fields no longer exist in the new UI
@@ -59,7 +60,7 @@ export async function configureLearningScenario(
 
   // Fill instructions field
   await page
-    .getByRole('textbox', { name: 'Instruktionen' })
+    .getByTestId('learning-scenario-instructions-input')
     .fill(
       data?.additionalInstructions ??
         'Der Chatbot soll aus der Perspektive eines Soldaten im Herrschaftssystem unter Ludwig XIV antworten.',
@@ -67,12 +68,12 @@ export async function configureLearningScenario(
 
   // Fill student exercise field
   await page
-    .getByRole('textbox', { name: 'Arbeitsauftrag' })
+    .getByTestId('learning-scenario-student-exercise-input')
     .fill(
       data?.studentExercise ??
         'Schüler sollen den Unterschied zwischen Absolutismus und Demokratie verstehen.',
     );
 
-  // Wait for autosave to complete (triggered by blur on last field)
+  await page.getByTestId('custom-chat-save-button').first().click();
   await waitForAutosave(page);
 }

--- a/apps/dialog/e2e/utils/learning-scenario.ts
+++ b/apps/dialog/e2e/utils/learning-scenario.ts
@@ -44,16 +44,19 @@ export async function configureLearningScenario(
     additionalInstructions?: string;
   },
 ) {
-  // Fill name field and blur for auto-save
+  // Fill name field
   await page
     .getByTestId('learning-scenario-name-input')
     .fill(data?.name ?? 'Absolutismus unter Ludwig XIV – Gruppe 1 Soldaten');
   await page.getByTestId('learning-scenario-name-input').press('Tab');
+  await waitForAutosave(page);
 
   // Fill description field
   await page
     .getByTestId('learning-scenario-description-input')
     .fill(data?.description ?? 'Zwischen Absolutismus und Demokratie (Ludwig XIV)');
+  await page.getByTestId('learning-scenario-description-input').press('Tab');
+  await waitForAutosave(page);
 
   // Note: schoolType, gradeLevel, and subject fields no longer exist in the new UI
   // They have been consolidated into the instructions field
@@ -65,6 +68,8 @@ export async function configureLearningScenario(
       data?.additionalInstructions ??
         'Der Chatbot soll aus der Perspektive eines Soldaten im Herrschaftssystem unter Ludwig XIV antworten.',
     );
+  await page.getByTestId('learning-scenario-instructions-input').press('Tab');
+  await waitForAutosave(page);
 
   // Fill student exercise field
   await page
@@ -73,7 +78,6 @@ export async function configureLearningScenario(
       data?.studentExercise ??
         'Schüler sollen den Unterschied zwischen Absolutismus und Demokratie verstehen.',
     );
-
-  await page.getByTestId('custom-chat-save-button').first().click();
+  await page.getByTestId('learning-scenario-student-exercise-input').press('Tab');
   await waitForAutosave(page);
 }

--- a/apps/dialog/e2e/utils/login.ts
+++ b/apps/dialog/e2e/utils/login.ts
@@ -19,7 +19,7 @@ export async function login(page: Page, user: string, password = 'password') {
     await page.waitForURL('/login');
   }
 
-  await page.getByRole('button', { name: 'Mit VIDIS einloggen' }).click();
+  await page.getByTestId('vidis-login-button').click();
 
   await page.getByLabel('Username').fill(user);
   await page.getByRole('textbox', { name: 'Password' }).fill(password);

--- a/apps/dialog/e2e/utils/utils.ts
+++ b/apps/dialog/e2e/utils/utils.ts
@@ -14,6 +14,5 @@ export async function waitForChatHistory(page: Page) {
 }
 
 export async function waitForAutosave(page: Page) {
-  await page.getByTestId('custom-chat-save-button').first().click();
   await expect(page.getByTestId('autosave-saved').first()).toBeVisible({ timeout: 5000 });
 }

--- a/apps/dialog/e2e/utils/utils.ts
+++ b/apps/dialog/e2e/utils/utils.ts
@@ -9,6 +9,11 @@ export async function waitForToastDisappear(page: Page) {
 }
 
 export async function waitForChatHistory(page: Page) {
-  await page.getByLabel('Chat suchen').waitFor();
+  await page.getByTestId('chat-search').waitFor();
   await expect(page.getByTestId('chat-history-loading')).toBeHidden();
+}
+
+export async function waitForAutosave(page: Page) {
+  await page.getByTestId('custom-chat-save-button').first().click();
+  await expect(page.getByTestId('autosave-saved').first()).toBeVisible({ timeout: 5000 });
 }

--- a/apps/dialog/e2e/utils/utils.ts
+++ b/apps/dialog/e2e/utils/utils.ts
@@ -7,3 +7,8 @@ export async function waitForToast(page: Page, msg?: string) {
 export async function waitForToastDisappear(page: Page) {
   await expect(page.getByLabel('Notifications (F8)').locator('li')).toBeHidden();
 }
+
+export async function waitForChatHistory(page: Page) {
+  await page.getByLabel('Chat suchen').waitFor();
+  await expect(page.getByTestId('chat-history-loading')).toBeHidden();
+}

--- a/apps/dialog/package.json
+++ b/apps/dialog/package.json
@@ -91,6 +91,7 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.11.1",
     "@eslint/eslintrc": "3.3.5",
     "@playwright/test": "1.59.1",
     "@dotenvx/dotenvx": "1.59.1",

--- a/apps/dialog/src/app/(authed)/(dialog)/assistants/assistant-overview.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/assistants/assistant-overview.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useCallback, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { OverviewFilter } from '@shared/overview-filter';
 import { AssistantWithImage } from '../custom/utils';
@@ -17,7 +16,6 @@ type AssistantOverviewProps = {
 };
 
 export default function AssistantOverview({ currentUserId }: AssistantOverviewProps) {
-  const router = useRouter();
   const t = useTranslations('custom-gpt');
   const [visibleAssistants, setVisibleAssistants] = useState<AssistantWithImage[]>([]);
 
@@ -31,17 +29,6 @@ export default function AssistantOverview({ currentUserId }: AssistantOverviewPr
   async function handleFilterChange(filter: OverviewFilter) {
     await setActiveFilter(filter);
   }
-
-  const handleCardClick = (gptId: string) => {
-    const assistant = visibleAssistants.find((gpt) => gpt.id === gptId);
-    if (assistant) {
-      if (assistant.userId === currentUserId) {
-        router.push(`/assistants/editor/${gptId}`);
-      } else {
-        router.push(`/assistants/${gptId}`);
-      }
-    }
-  };
 
   const infoContent = (
     <div className="flex flex-col gap-8 whitespace-pre-line">
@@ -80,8 +67,12 @@ export default function AssistantOverview({ currentUserId }: AssistantOverviewPr
             description={assistant.description}
             avatarUrl={assistant.maybeSignedPictureUrl}
             isOwned={assistant.userId === currentUserId}
-            onCardClick={() => handleCardClick(assistant.id)}
-            onChatClick={() => router.push(`/assistants/d/${assistant.id}`)}
+            href={
+              assistant.userId === currentUserId
+                ? `/assistants/editor/${assistant.id}`
+                : `/assistants/${assistant.id}`
+            }
+            chatHref={`/assistants/d/${assistant.id}`}
           />
         ));
       }}

--- a/apps/dialog/src/app/(authed)/(dialog)/characters/character-overview.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/characters/character-overview.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useCallback, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { OverviewFilter } from '@shared/overview-filter';
 import { CharacterWithImage } from './utils';
@@ -17,7 +16,6 @@ type CharacterOverviewProps = {
 };
 
 export default function CharacterOverview({ currentUserId }: CharacterOverviewProps) {
-  const router = useRouter();
   const t = useTranslations('characters');
   const [visibleCharacters, setVisibleCharacters] = useState<CharacterWithImage[]>([]);
 
@@ -67,12 +65,8 @@ export default function CharacterOverview({ currentUserId }: CharacterOverviewPr
               description={character.description}
               avatarUrl={character.maybeSignedPictureUrl}
               isOwned={isOwned}
-              onCardClick={() =>
-                router.push(
-                  isOwned ? `/characters/editor/${character.id}` : `/characters/${character.id}`,
-                )
-              }
-              onChatClick={() => router.push(`/characters/d/${character.id}`)}
+              href={isOwned ? `/characters/editor/${character.id}` : `/characters/${character.id}`}
+              chatHref={`/characters/d/${character.id}`}
             />
           );
         });

--- a/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/_components/shared-chat-login-form.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/_components/shared-chat-login-form.tsx
@@ -38,9 +38,12 @@ export default function SharedChatLoginForm() {
 
   return (
     <form className="flex flex-col gap-4 w-full">
-      <h2 className="text-3xl mb-2 font-medium text-center w-full">{t('join-code')}</h2>
+      <h2 id="login-invite-code-label" className="text-3xl mb-2 font-medium text-center w-full">
+        {t('join-code')}
+      </h2>
       <input
         id="login-invite-code"
+        aria-labelledby="login-invite-code-label"
         value={inviteCode}
         onChange={(e) => setInviteCode(e.target.value)}
         onKeyDown={(e) => {

--- a/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/learning-scenario-overview.tsx
+++ b/apps/dialog/src/app/(authed)/(dialog)/learning-scenarios/learning-scenario-overview.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useCallback, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { OverviewFilter } from '@shared/overview-filter';
 import { LearningScenarioWithImage } from '@shared/learning-scenarios/learning-scenario-service';
@@ -17,7 +16,6 @@ type LearningScenarioOverviewProps = {
 };
 
 export default function LearningScenarioOverview({ currentUserId }: LearningScenarioOverviewProps) {
-  const router = useRouter();
   const t = useTranslations('learning-scenarios');
   const [visibleLearningScenarios, setVisibleLearningScenarios] = useState<
     LearningScenarioWithImage[]
@@ -69,12 +67,10 @@ export default function LearningScenarioOverview({ currentUserId }: LearningScen
               description={scenario.description}
               avatarUrl={scenario.maybeSignedPictureUrl}
               isOwned={isOwned}
-              onCardClick={() =>
-                router.push(
-                  isOwned
-                    ? `/learning-scenarios/editor/${scenario.id}`
-                    : `/learning-scenarios/${scenario.id}`,
-                )
+              href={
+                isOwned
+                  ? `/learning-scenarios/editor/${scenario.id}`
+                  : `/learning-scenarios/${scenario.id}`
               }
             />
           );

--- a/apps/dialog/src/app/(unauth)/login/login-form.tsx
+++ b/apps/dialog/src/app/(unauth)/login/login-form.tsx
@@ -27,6 +27,7 @@ export default function LoginForm() {
           className={cn(buttonSecondaryClassName, 'w-full')}
           onClick={() => signIn('vidis', { callbackUrl })}
           aria-label="Mit VIDIS einloggen"
+          data-testid="vidis-login-button"
         >
           Mit VIDIS einloggen
         </button>

--- a/apps/dialog/src/components/custom-chat/custom-chat-form-state.tsx
+++ b/apps/dialog/src/components/custom-chat/custom-chat-form-state.tsx
@@ -30,7 +30,7 @@ export function CustomChatFormState({
         </span>
       )}
       {!isSubmitting && !isDirty && !hasSaveError && (
-        <span className="flex items-center gap-1">
+        <span className="flex items-center gap-1" data-testid="autosave-saved">
           <CheckCircleIcon className="size-5 text-success" /> {t('saved')}
         </span>
       )}

--- a/apps/dialog/src/components/entity-overview/entity-card.tsx
+++ b/apps/dialog/src/components/entity-overview/entity-card.tsx
@@ -1,19 +1,21 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import { cn } from '@/utils/tailwind';
 import { truncateClassName } from '@/utils/tailwind/truncate';
 import AvatarPicture from '@/components/common/avatar-picture';
 import { useTranslations } from 'next-intl';
 import { ChatTextIcon, ImageSquareIcon } from '@phosphor-icons/react';
+import { IconButton } from '@ui/components/IconButton';
 
 type EntityCardProps = {
   name: string;
   description: string | null;
   avatarUrl: string | undefined;
   isOwned: boolean;
-  onCardClick: () => void;
-  onChatClick?: () => void;
+  href: string;
+  chatHref?: string;
 };
 
 export default function EntityCard({
@@ -21,65 +23,49 @@ export default function EntityCard({
   description,
   avatarUrl,
   isOwned,
-  onCardClick,
-  onChatClick,
+  href,
+  chatHref,
 }: EntityCardProps) {
   const t = useTranslations('entity-overview');
   const tCommon = useTranslations('common');
 
-  function handleChatClick(e: React.MouseEvent) {
-    e.stopPropagation();
-    onChatClick?.();
-  }
-
   return (
-    <div
-      onClick={onCardClick}
-      className="rounded-enterprise-md border p-4 flex items-center gap-4 w-full hover:border-primary cursor-pointer bg-card"
-      tabIndex={0}
-      aria-label={name}
-      role="button"
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onCardClick();
-        }
-      }}
-    >
-      <figure className="w-15 h-15 bg-light-gray rounded-full flex justify-center items-center shrink-0">
-        {avatarUrl ? (
-          <AvatarPicture src={avatarUrl} alt={`${name} Avatar`} variant="smallCircle" />
-        ) : (
-          <ImageSquareIcon className="w-8 h-8 text-primary" aria-hidden="true" weight="thin" />
-        )}
-      </figure>
+    <div className="rounded-enterprise-md border flex items-center w-full hover:border-primary bg-card has-[[data-card-link]:focus-visible]:ring-2 has-[[data-card-link]:focus-visible]:ring-ring">
+      <Link
+        href={href}
+        aria-label={name}
+        data-card-link
+        className="flex items-center gap-4 grow min-w-0 p-4 outline-none"
+      >
+        <figure className="w-15 h-15 bg-light-gray rounded-full flex justify-center items-center shrink-0">
+          {avatarUrl ? (
+            <AvatarPicture src={avatarUrl} alt={`${name} Avatar`} variant="smallCircle" />
+          ) : (
+            <ImageSquareIcon className="w-8 h-8 text-primary" aria-hidden="true" weight="thin" />
+          )}
+        </figure>
 
-      <div className="flex flex-col gap-1 text-left min-w-0">
-        <div className="flex items-center gap-2">
-          <h2 className={cn('font-medium leading-none py-0.5', truncateClassName)}>{name}</h2>
-          {isOwned && (
-            <span className="hidden sm:inline-flex items-center rounded-full bg-primary/15 px-2 py-0.5 text-[11px] font-semibold text-primary shrink-0 uppercase tracking-wider">
-              {t('badge-mine')}
-            </span>
+        <div className="flex flex-col gap-1 text-left min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className={cn('font-medium leading-none py-0.5', truncateClassName)}>{name}</h2>
+            {isOwned && (
+              <span className="hidden sm:inline-flex items-center rounded-full bg-primary/15 px-2 py-0.5 text-[11px] font-semibold text-primary shrink-0 uppercase tracking-wider">
+                {t('badge-mine')}
+              </span>
+            )}
+          </div>
+          {description && (
+            <span className={cn(truncateClassName, 'text-gray-600')}>{description}</span>
           )}
         </div>
-        {description && (
-          <span className={cn(truncateClassName, 'text-gray-600')}>{description}</span>
-        )}
-      </div>
+      </Link>
 
-      <div className="grow" />
-
-      {onChatClick && (
-        <button
-          type="button"
-          aria-label={tCommon('new-chat')}
-          onClick={handleChatClick}
-          className="p-1 rounded-enterprise-sm hover:bg-gray-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <ChatTextIcon aria-hidden="true" className="w-6 h-6 text-primary" />
-          <span className="sr-only">{tCommon('new-chat')}</span>
-        </button>
+      {chatHref && (
+        <IconButton asChild className="shrink-0 p-1 mx-4">
+          <Link href={chatHref} aria-label={tCommon('new-chat')}>
+            <ChatTextIcon aria-hidden="true" className="w-6 h-6 text-primary" />
+          </Link>
+        </IconButton>
       )}
     </div>
   );

--- a/apps/dialog/src/components/entity-overview/entity-card.tsx
+++ b/apps/dialog/src/components/entity-overview/entity-card.tsx
@@ -30,12 +30,16 @@ export default function EntityCard({
   const tCommon = useTranslations('common');
 
   return (
-    <div className="rounded-enterprise-md border flex items-center w-full hover:border-primary bg-card has-[[data-card-link]:focus-visible]:ring-2 has-[[data-card-link]:focus-visible]:ring-ring">
+    <div
+      className="rounded-enterprise-md border flex items-center w-full hover:border-primary bg-card has-[[data-card-link]:focus-visible]:ring-2 has-[[data-card-link]:focus-visible]:ring-ring"
+      data-testid="entity-card"
+    >
       <Link
         href={href}
         aria-label={name}
         data-card-link
         className="flex items-center gap-4 grow min-w-0 p-4 outline-none"
+        data-testid="entity-link"
       >
         <figure className="w-15 h-15 bg-light-gray rounded-full flex justify-center items-center shrink-0">
           {avatarUrl ? (
@@ -61,7 +65,7 @@ export default function EntityCard({
       </Link>
 
       {chatHref && (
-        <IconButton asChild className="shrink-0 p-1 mx-4">
+        <IconButton asChild className="shrink-0 p-1 mx-4" data-testid="chat-button">
           <Link href={chatHref} aria-label={tCommon('new-chat')}>
             <ChatTextIcon aria-hidden="true" className="w-6 h-6 text-primary" />
           </Link>

--- a/apps/dialog/src/components/entity-overview/entity-overview.tsx
+++ b/apps/dialog/src/components/entity-overview/entity-overview.tsx
@@ -195,7 +195,7 @@ export default function EntityOverview({
 
         <div className="overflow-auto px-6 pb-6">
           <div className="max-w-3xl mx-auto w-full">
-            <div className="flex flex-col gap-2 w-full">{children(searchInput, sortBy)}</div>
+            <div className="flex flex-col gap-2 w-full py-1">{children(searchInput, sortBy)}</div>
           </div>
         </div>
       </div>

--- a/apps/dialog/src/components/navigation/sidebar/chat-history.tsx
+++ b/apps/dialog/src/components/navigation/sidebar/chat-history.tsx
@@ -90,6 +90,7 @@ export function ChatHistory() {
             placeholder={t('chat-search-placeholder')}
             aria-label={t('chat-search-placeholder')}
             onChange={(event) => setSearchText(event.target.value)}
+            data-testid="chat-search"
           />
           <InputGroupAddon align="inline-end">
             {searchText.length === 0 ? (

--- a/apps/dialog/src/components/navigation/sidebar/chat-history.tsx
+++ b/apps/dialog/src/components/navigation/sidebar/chat-history.tsx
@@ -10,7 +10,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { useCustomPathname } from '@/hooks/use-custom-pathname';
-import { useMemo, useState, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { SidebarGroup, SidebarMenu } from '@ui/components/Sidebar';
 import { ChatHistoryItem } from './chat-history-item';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@ui/components/InputGroup';
@@ -131,7 +131,7 @@ export function ChatHistory() {
       </SidebarGroup>
 
       {isLoading && (
-        <div className="flex flex-col w-full items-center ">
+        <div className="flex flex-col w-full items-center" data-testid="chat-history-loading">
           <Spinner aria-label={t('chats-loading')} />
         </div>
       )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
       eslint-config-prettier:
         specifier: 10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
@@ -454,6 +454,9 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.11.1
+        version: 4.11.1(playwright-core@1.59.1)
       '@dotenvx/dotenvx':
         specifier: 1.59.1
         version: 1.59.1
@@ -510,7 +513,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
       eslint-config-prettier:
         specifier: 10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
@@ -916,7 +919,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
       eslint-config-prettier:
         specifier: 10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
@@ -1155,6 +1158,11 @@ packages:
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
+
+  '@axe-core/playwright@4.11.1':
+    resolution: {integrity: sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -9613,6 +9621,11 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@axe-core/playwright@4.11.1(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.2
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -14540,26 +14553,6 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2):
-    dependencies:
-      '@next/eslint-plugin-next': 16.2.2
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
-      globals: 16.4.0
-      typescript-eslint: 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
@@ -14589,7 +14582,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14628,33 +14621,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
This pull request introduces accessibility improvements and a refactor of entity overview cards to use semantic links instead of click handlers, enhancing both usability and testability. It also adds automated accessibility testing using axe-core with Playwright.

**Accessibility Improvements and Automated Testing:**

* Added an end-to-end accessibility test suite using `@axe-core/playwright` and Playwright to check for WCAG 2.0/2.1 A and AA violations across key pages, with the color-contrast rule temporarily disabled.
* Improved accessibility of the shared chat login form by associating the invite code input with a visible label using `aria-labelledby`.

**Entity Card Refactor and Navigation:**

* Refactored `EntityCard` and related overview components (`assistant-overview.tsx`, `character-overview.tsx`, `learning-scenario-overview.tsx`) to use semantic `Link` components for navigation instead of custom click handlers, improving accessibility and simplifying the code. Chat actions are now exposed via explicit `chatHref` props and `IconButton` components.