### PR TITLE
TD-1112 update llm models in e2e tests

### DIFF
--- a/apps/dialog/e2e/global-setup.ts
+++ b/apps/dialog/e2e/global-setup.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import { chromium, FullConfig } from '@playwright/test';
 import { login } from './utils/login';
 import { AUTH_FILES } from './utils/const';
+import { selectDifferentModel } from './utils/chat';
+import { LLM_MODELS } from './utils/llm-models';
 
 /**
  * Global Playwright setup — runs once before all test suites.
@@ -33,6 +35,7 @@ export default async function globalSetup(config: FullConfig) {
     const page = await context.newPage();
 
     await login(page, user);
+    await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
     await context.storageState({ path: file });
 
     await page.close();

--- a/apps/dialog/e2e/tests/character/character-chat-ux.test.ts
+++ b/apps/dialog/e2e/tests/character/character-chat-ux.test.ts
@@ -3,6 +3,7 @@ import { AUTH_FILES } from '../../utils/const';
 import { enterMessage, selectDifferentModel, sendMessage } from '../../utils/chat';
 import { configureCharacter, deleteCharacter } from '../../utils/character';
 import { waitForToast } from '../../utils/utils';
+import { LLM_MODELS } from '../../utils/llm-models';
 import { nanoid } from 'nanoid';
 
 /**
@@ -30,8 +31,8 @@ async function createCharacterWithInitialMessage(
 
   const url = page.url();
   // URL shape: /characters/editor/[characterId]
-  const characterId = url.split('/characters/editor/')[1]!.split('?')[0]!;
-  return characterId;
+  const [characterId] = url.split('/characters/editor/')[1]!.split('?');
+  return characterId ?? '';
 }
 
 test.describe('character chat UX', () => {
@@ -50,6 +51,12 @@ test.describe('character chat UX', () => {
   test.afterAll(async ({ browser }) => {
     if (!characterId) return;
     const page = await browser.newPage({ storageState: AUTH_FILES.teacher });
+
+    // restore default text model
+    await page.goto('/');
+    await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
+
+    // delete character
     await page.goto('/characters');
     await page.waitForURL('/characters');
     await deleteCharacter(page, characterName);
@@ -57,6 +64,7 @@ test.describe('character chat UX', () => {
     await expect(deleteConfirmButton).toBeVisible();
     await deleteConfirmButton.click();
     await waitForToast(page, 'Der Dialogpartner wurde erfolgreich gelöscht.');
+
     await page.close();
   });
 
@@ -110,8 +118,8 @@ test.describe('character chat UX', () => {
     const prompt = 'Dieser Prompt soll beim Modellwechsel nicht verschwinden';
     await enterMessage(page, prompt);
 
-    // Switch model
-    await selectDifferentModel(page);
+    // Switch model to the secondary model
+    await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_2);
 
     // Entered prompt should not be cleared
     await expect(page.getByPlaceholder('Wie kann ich Dir helfen?')).toHaveValue(prompt);

--- a/apps/dialog/e2e/tests/character/character-chat-ux.test.ts
+++ b/apps/dialog/e2e/tests/character/character-chat-ux.test.ts
@@ -31,8 +31,9 @@ async function createCharacterWithInitialMessage(
 
   const url = page.url();
   // URL shape: /characters/editor/[characterId]
-  const [characterId] = url.split('/characters/editor/')[1]!.split('?');
-  return characterId ?? '';
+  const [characterId] = url.split('/characters/editor/')[1]?.split('?') ?? [];
+  if (!characterId) throw new Error(`Unexpected URL shape, could not extract characterId: ${url}`);
+  return characterId;
 }
 
 test.describe('character chat UX', () => {
@@ -52,20 +53,22 @@ test.describe('character chat UX', () => {
     if (!characterId) return;
     const page = await browser.newPage({ storageState: AUTH_FILES.teacher });
 
-    // restore default text model
-    await page.goto('/');
-    await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
+    try {
+      // restore default text model
+      await page.goto('/');
+      await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
 
-    // delete character
-    await page.goto('/characters');
-    await page.waitForURL('/characters');
-    await deleteCharacter(page, characterName);
-    const deleteConfirmButton = page.getByRole('button', { name: 'Löschen' });
-    await expect(deleteConfirmButton).toBeVisible();
-    await deleteConfirmButton.click();
-    await waitForToast(page, 'Der Dialogpartner wurde erfolgreich gelöscht.');
-
-    await page.close();
+      // delete character
+      await page.goto('/characters');
+      await page.waitForURL('/characters');
+      await deleteCharacter(page, characterName);
+      const deleteConfirmButton = page.getByRole('button', { name: 'Löschen' });
+      await expect(deleteConfirmButton).toBeVisible();
+      await deleteConfirmButton.click();
+      await waitForToast(page, 'Der Dialogpartner wurde erfolgreich gelöscht.');
+    } finally {
+      await page.close();
+    }
   });
 
   test('character initial message is visible in conversation (new conversation and opened from history)', async ({

--- a/apps/dialog/e2e/tests/generic-chat/chat-file-upload.test.ts
+++ b/apps/dialog/e2e/tests/generic-chat/chat-file-upload.test.ts
@@ -1,11 +1,20 @@
 import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
 import { deleteChat, selectDifferentModel, sendMessage, uploadFile } from '../../utils/chat';
+import { LLM_MODELS } from '../../utils/llm-models';
 import path from 'path';
 
-const modelWithImageSupport = 'GPT-5 nano';
-
 test.use({ storageState: AUTH_FILES.teacher });
+
+test.afterAll(async ({ browser }) => {
+  const page = await browser.newPage({ storageState: AUTH_FILES.teacher });
+
+  // restore default text model
+  await page.goto('/');
+  await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
+
+  await page.close();
+});
 
 test('should successfully upload a file and get response about its contents', async ({ page }) => {
   await page.goto('/');
@@ -31,7 +40,7 @@ test('should successfully upload an image and get response about its contents', 
   page,
 }) => {
   await page.goto('/');
-  await selectDifferentModel(page, modelWithImageSupport);
+  await selectDifferentModel(page, LLM_MODELS.IMAGE_CAPABLE_MODEL);
 
   await uploadFile(page, './e2e/fixtures/lazy.webp');
 

--- a/apps/dialog/e2e/tests/generic-chat/chat-file-upload.test.ts
+++ b/apps/dialog/e2e/tests/generic-chat/chat-file-upload.test.ts
@@ -9,11 +9,13 @@ test.use({ storageState: AUTH_FILES.teacher });
 test.afterAll(async ({ browser }) => {
   const page = await browser.newPage({ storageState: AUTH_FILES.teacher });
 
-  // restore default text model
-  await page.goto('/');
-  await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
-
-  await page.close();
+  try {
+    // restore default text model
+    await page.goto('/');
+    await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
+  } finally {
+    await page.close();
+  }
 });
 
 test('should successfully upload a file and get response about its contents', async ({ page }) => {

--- a/apps/dialog/e2e/tests/generic-chat/model-selection.test.ts
+++ b/apps/dialog/e2e/tests/generic-chat/model-selection.test.ts
@@ -1,8 +1,19 @@
 import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
 import { selectDifferentModel } from '../../utils/chat';
+import { LLM_MODELS } from '../../utils/llm-models';
 
 test.use({ storageState: AUTH_FILES.teacher });
+
+test.afterAll(async ({ browser }) => {
+  const page = await browser.newPage({ storageState: AUTH_FILES.teacher });
+
+  // restore default text model
+  await page.goto('/');
+  await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
+
+  await page.close();
+});
 
 test('switching LLM model preserves the typed prompt in generic chat', async ({ page }) => {
   await page.goto('/');
@@ -10,8 +21,10 @@ test('switching LLM model preserves the typed prompt in generic chat', async ({ 
   const prompt = 'This prompt must not disappear when changing models';
   await page.getByPlaceholder('Wie kann ich Dir helfen?').fill(prompt);
 
-  await selectDifferentModel(page);
+  // Switch to the second model
+  await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_2);
 
+  // Verify prompt is preserved
   await expect(page.getByPlaceholder('Wie kann ich Dir helfen?')).toHaveValue(prompt);
 });
 

--- a/apps/dialog/e2e/tests/generic-chat/model-selection.test.ts
+++ b/apps/dialog/e2e/tests/generic-chat/model-selection.test.ts
@@ -8,11 +8,13 @@ test.use({ storageState: AUTH_FILES.teacher });
 test.afterAll(async ({ browser }) => {
   const page = await browser.newPage({ storageState: AUTH_FILES.teacher });
 
-  // restore default text model
-  await page.goto('/');
-  await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
-
-  await page.close();
+  try {
+    // restore default text model
+    await page.goto('/');
+    await selectDifferentModel(page, LLM_MODELS.TEXT_MODEL_1);
+  } finally {
+    await page.close();
+  }
 });
 
 test('switching LLM model preserves the typed prompt in generic chat', async ({ page }) => {

--- a/apps/dialog/e2e/utils/chat.ts
+++ b/apps/dialog/e2e/utils/chat.ts
@@ -40,7 +40,7 @@ export async function uploadFile(page: Page, filePath: string) {
   await page.locator('form svg.animate-spin').waitFor({ state: 'detached' });
 }
 
-/** Opens the LLM model dropdown and selects the first available alternative model. */
+/** Opens the LLM model dropdown and selects a specific model by displayName, or the first available alternative if no name is provided. */
 export async function selectDifferentModel(page: Page, modelName?: string) {
   const dropdown = page.getByLabel('Select text Model Dropdown');
   await expect(dropdown).toBeVisible();

--- a/apps/dialog/e2e/utils/llm-models.ts
+++ b/apps/dialog/e2e/utils/llm-models.ts
@@ -1,0 +1,6 @@
+/** Shared LLM model configuration for e2e tests. */
+export const LLM_MODELS = {
+  TEXT_MODEL_1: 'Mistral Nemo Instruct',
+  TEXT_MODEL_2: 'Llama-3.1-8B',
+  IMAGE_CAPABLE_MODEL: 'GPT-5 nano',
+} as const;

--- a/packages/api-database/src/seed.ts
+++ b/packages/api-database/src/seed.ts
@@ -66,7 +66,7 @@ const DEFAULT_MODELS: LlmInsertModel[] = [
     provider: 'ionos',
     name: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
     displayName: 'Llama-3.1-8B',
-    description: 'Effizient für leichtere Aufgaben',
+    description: 'Efficient for lighter tasks',
     setting: {
       provider: 'ionos',
       apiKey: ionosApiKey,
@@ -84,7 +84,7 @@ const DEFAULT_MODELS: LlmInsertModel[] = [
     provider: 'ionos',
     name: 'mistralai/Mistral-Nemo-Instruct-2407',
     displayName: 'Mistral Nemo Instruct',
-    description: 'multilingual, Open Source und effizient',
+    description: 'Multilingual, open source and efficient',
     setting: {
       provider: 'ionos',
       apiKey: ionosApiKey,

--- a/packages/api-database/src/seed.ts
+++ b/packages/api-database/src/seed.ts
@@ -64,9 +64,9 @@ const DEFAULT_MODELS: LlmInsertModel[] = [
     id: '9578ed80-b0c2-4968-b253-d897576e5512',
     organizationId: ORGANIZATION_ID,
     provider: 'ionos',
-    name: 'meta-llama/Llama-3.3-70B-Instruct',
-    displayName: 'Llama-3.3-70B',
-    description: 'Llama-3.3-70B model for testing',
+    name: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+    displayName: 'Llama-3.1-8B',
+    description: 'Effizient für leichtere Aufgaben',
     setting: {
       provider: 'ionos',
       apiKey: ionosApiKey,
@@ -74,8 +74,26 @@ const DEFAULT_MODELS: LlmInsertModel[] = [
     },
     priceMetadata: {
       type: 'text',
-      promptTokenPrice: 150, // 0.15 € per 1M tokens
-      completionTokenPrice: 250, // 0.25 € per 1M tokens
+      promptTokenPrice: 170,
+      completionTokenPrice: 280,
+    },
+  },
+  {
+    id: '038ac4d1-c8c9-49a1-a2f9-c269b07961aa',
+    organizationId: ORGANIZATION_ID,
+    provider: 'ionos',
+    name: 'mistralai/Mistral-Nemo-Instruct-2407',
+    displayName: 'Mistral Nemo Instruct',
+    description: 'multilingual, Open Source und effizient',
+    setting: {
+      provider: 'ionos',
+      apiKey: ionosApiKey,
+      baseUrl: ionosBaseUrl,
+    },
+    priceMetadata: {
+      type: 'text',
+      promptTokenPrice: 150,
+      completionTokenPrice: 150,
     },
   },
   {


### PR DESCRIPTION
* Mistral Nemo Instruct is now used by default for e2e tests.
* Seed Llama-3.1-8B instead of Llama-3.3-70B