### PR TITLE
fix: image generation for ionos provider

### DIFF
--- a/packages/ai-core/src/images/providers/ionos.ts
+++ b/packages/ai-core/src/images/providers/ionos.ts
@@ -20,7 +20,7 @@ export function constructIonosImageGenerationFn(llmModel: AiModel): ImageGenerat
       model,
       prompt,
       n: 1,
-      size: '1024x1024',
+      size: '1024*1024',
       response_format: 'b64_json',
     });
 


### PR DESCRIPTION
See API spec, the size should be `1024*1024` instead of `1024x1024`.
https://api.ionos.com/docs/inference-openai/v1/#tag/OpenAI-Compatible-Endpoints/operation/openaiCompatImagesGenerationsPost