### PR TITLE
TD-1180: dropdown is closing after action

### DIFF
--- a/apps/dialog/src/app/(unauth)/ua/download-shared-conversation-button.tsx
+++ b/apps/dialog/src/app/(unauth)/ua/download-shared-conversation-button.tsx
@@ -29,8 +29,15 @@ export default function DownloadSharedConversationButton({
   inviteCode,
 }: DownloadConversationButtonProps) {
   const [isLoading, setIsLoading] = React.useState(false);
+  const isMountedRef = React.useRef(true);
   const toast = useToast();
   const tCommon = useTranslations('common');
+
+  React.useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   async function handleDownload() {
     if (disabled) {
@@ -70,7 +77,9 @@ export default function DownloadSharedConversationButton({
     } catch {
       toast.error('Der Download der Konversation ist fehlgeschlagen.');
     } finally {
-      setIsLoading(false);
+      if (isMountedRef.current) {
+        setIsLoading(false);
+      }
     }
   }
 

--- a/apps/dialog/src/components/navigation/profile-menu.tsx
+++ b/apps/dialog/src/components/navigation/profile-menu.tsx
@@ -15,15 +15,12 @@ import { DotsThreeIcon } from '@phosphor-icons/react';
 function MenuActionRow({ action }: { action: React.ReactNode }) {
   const contentRef = React.useRef<HTMLDivElement>(null);
 
-  function handleSelect(event: Event) {
+  function handleSelect() {
     const childElement = contentRef.current?.querySelector<HTMLElement>(
       'button, a, [role="button"]',
     );
 
-    if (childElement) {
-      event.preventDefault();
-      childElement.click();
-    }
+    childElement?.click();
   }
 
   return (


### PR DESCRIPTION
Some changes were needed from the original fix so the dropdown is closing after the action was performed (Delete, Download, etc)