### PR TITLE
chore: set allowBuilds for required packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,14 +2,14 @@ packages:
   - 'apps/*'
   - 'packages/*'
 allowBuilds:
-  '@parcel/watcher': false
+  '@parcel/watcher': true
   '@sentry-internal/node-cpu-profiler': false
-  '@sentry/cli': false
-  '@swc/core': false
-  esbuild: false
+  '@sentry/cli': true
+  '@swc/core': true
+  esbuild: true
   protobufjs: false
-  sharp: false
-  unrs-resolver: false
+  sharp: true
+  unrs-resolver: true
 overrides:
   glob@<11.1.0: 11.1.0
   minimatch@>=9.0.0 <9.0.7: 9.0.7


### PR DESCRIPTION
| Package | Why it needs builds | Recommendation |
|---|---|---|
| `@swc/core` | Downloads platform-specific native binary; Next.js uses it as its compiler - **completely non-functional without it** | `true` |
| `esbuild` | Binary-only bundler; downloads platform binary - **completely non-functional without it** | `true` |
| `sharp` | Downloads/compiles native libvips bindings; Next.js image optimization uses it | `true` |
| `@parcel/watcher` | Downloads prebuilt native binaries for efficient file-system watching (used by Next.js dev mode) | `true` |
| `@sentry/cli` | Downloads the Sentry CLI binary; needed for source map uploads in CI/build | `true` |
| `unrs-resolver` | Rust-based module resolver with native addon; used by ESLint/tooling in the ecosystem | `true` |
| `protobufjs` | Runs a JS compatibility postinstall script - pure JS fallback works fine | `false` |
| `@sentry-internal/node-cpu-profiler` | Optional Sentry CPU profiling native addon - not core functionality | `false` |