### PR TITLE
TD-1258: add Sentry GenAI spans to agentic chat loop

### DIFF
--- a/apps/chat-bot/src/app/api/chat/agent-loop.ts
+++ b/apps/chat-bot/src/app/api/chat/agent-loop.ts
@@ -19,6 +19,7 @@ type AgentLoopParams = {
   messages: AiCoreMessage[];
   tools?: ToolDefinition[];
   toolHandlers?: Record<string, ToolHandler>;
+  agentName: string;
   onTextChunk: (delta: string) => void;
   onToolCall?: (call: ToolCall) => void;
   onComplete: (result: { fullText: string; usage: TokenUsage; priceInCents: number }) => void;
@@ -31,6 +32,7 @@ export function runAgentLoop({
   messages,
   tools,
   toolHandlers,
+  agentName,
   onTextChunk,
   onComplete,
   onError,
@@ -45,12 +47,12 @@ export function runAgentLoop({
       await Sentry.startSpan(
         {
           op: 'gen_ai.invoke_agent',
-          name: 'invoke_agent AIS.chat',
+          name: `invoke_agent ${agentName}`,
           attributes: {
             'gen_ai.operation.name': 'invoke_agent',
             'gen_ai.operation.type': 'agent',
             'gen_ai.request.model': model.name,
-            'gen_ai.agent.name': 'AIS.chat',
+            'gen_ai.agent.name': agentName,
           },
         },
         async (agentSpan) => {

--- a/apps/chat-bot/src/app/api/chat/agent-loop.ts
+++ b/apps/chat-bot/src/app/api/chat/agent-loop.ts
@@ -6,6 +6,7 @@ import {
   type ToolCall,
 } from '@ais-chat/ai-core';
 import { logError } from '@shared/logging';
+import * as Sentry from '@sentry/nextjs';
 
 const MAX_AGENTIC_ITERATIONS = 3;
 const MAX_TOOL_CALLS_PER_ITERATION = 2;
@@ -13,7 +14,7 @@ const MAX_TOOL_CALLS_PER_ITERATION = 2;
 export type ToolHandler = (args: Record<string, unknown>) => Promise<string>;
 
 type AgentLoopParams = {
-  modelId: string;
+  model: { id: string; name: string };
   apiKeyId: string;
   messages: AiCoreMessage[];
   tools?: ToolDefinition[];
@@ -25,7 +26,7 @@ type AgentLoopParams = {
 };
 
 export function runAgentLoop({
-  modelId,
+  model,
   apiKeyId,
   messages,
   tools,
@@ -41,79 +42,118 @@ export function runAgentLoop({
     const loopMessages = [...messages];
 
     try {
-      for (let iteration = 0; iteration < MAX_AGENTIC_ITERATIONS; iteration++) {
-        const pendingToolCalls: ToolCall[] = [];
-        let iterationText = '';
-
-        const isLastIteration = iteration === MAX_AGENTIC_ITERATIONS - 1;
-        const stream = generateAgenticStreamWithBilling(
-          modelId,
-          loopMessages,
-          apiKeyId,
-          async ({ usage, priceInCents }) => {
-            totalUsage = {
-              promptTokens: totalUsage.promptTokens + usage.promptTokens,
-              completionTokens: totalUsage.completionTokens + usage.completionTokens,
-              totalTokens: totalUsage.totalTokens + usage.totalTokens,
-            };
-            totalPriceInCents += priceInCents;
+      await Sentry.startSpan(
+        {
+          op: 'gen_ai.invoke_agent',
+          name: 'invoke_agent AIS.chat',
+          attributes: {
+            'gen_ai.operation.name': 'invoke_agent',
+            'gen_ai.operation.type': 'agent',
+            'gen_ai.request.model': model.name,
+            'gen_ai.agent.name': 'AIS.chat',
           },
-          tools && tools.length > 0 && !isLastIteration ? { tools, toolChoice: 'auto' } : undefined,
-        );
+        },
+        async (agentSpan) => {
+          for (let iteration = 0; iteration < MAX_AGENTIC_ITERATIONS; iteration++) {
+            const pendingToolCalls: ToolCall[] = [];
+            let iterationText = '';
 
-        for await (const event of stream) {
-          if (event.type === 'text') {
-            iterationText += event.delta;
-            onTextChunk(event.delta);
-            // Don't flush to client yet — wait until we know there are no tool calls
-          } else if (event.type === 'tool_call') {
-            if (pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION) {
-              pendingToolCalls.push(event.call);
+            const isLastIteration = iteration === MAX_AGENTIC_ITERATIONS - 1;
+
+            const stream = generateAgenticStreamWithBilling(
+              model.id,
+              loopMessages,
+              apiKeyId,
+              async ({ usage, priceInCents }) => {
+                totalUsage = {
+                  promptTokens: totalUsage.promptTokens + usage.promptTokens,
+                  completionTokens: totalUsage.completionTokens + usage.completionTokens,
+                  totalTokens: totalUsage.totalTokens + usage.totalTokens,
+                };
+                totalPriceInCents += priceInCents;
+              },
+              tools && tools.length > 0 && !isLastIteration
+                ? { tools, toolChoice: 'auto' }
+                : undefined,
+            );
+
+            for await (const event of stream) {
+              if (event.type === 'text') {
+                iterationText += event.delta;
+                onTextChunk(event.delta);
+                // Don't flush to client yet — wait until we know there are no tool calls
+              } else if (event.type === 'tool_call') {
+                if (pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION) {
+                  pendingToolCalls.push(event.call);
+                }
+              }
+            }
+
+            // Tool-calling iteration
+            fullText += iterationText;
+
+            if (pendingToolCalls.length === 0) {
+              break;
+            }
+
+            // Append the assistant message with tool calls
+            const assistantMessage: AiCoreMessage = {
+              role: 'assistant',
+              content: iterationText,
+              toolCalls: pendingToolCalls,
+            };
+            loopMessages.push(assistantMessage);
+
+            // Execute tool calls in parallel and append results
+            const toolResults = await Promise.all(
+              pendingToolCalls.map((toolCall) =>
+                Sentry.startSpan(
+                  {
+                    op: 'gen_ai.execute_tool',
+                    name: `execute_tool ${toolCall.name}`,
+                    attributes: {
+                      'gen_ai.operation.name': 'execute_tool',
+                      'gen_ai.operation.type': 'tool',
+                      'gen_ai.tool.name': toolCall.name,
+                    },
+                  },
+                  async (toolSpan) => {
+                    const handler = toolHandlers?.[toolCall.name];
+                    let result: string;
+
+                    if (handler) {
+                      try {
+                        const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
+                        result = await handler(args);
+                      } catch (error) {
+                        const message =
+                          error instanceof Error ? error.message : 'Tool execution failed';
+                        toolSpan.setStatus({ code: 2, message });
+                        logError(`Error executing tool ${toolCall.name}:`, error);
+                        result = `Error: ${message}`;
+                      }
+                    } else {
+                      const message = `Unknown tool "${toolCall.name}"`;
+                      toolSpan.setStatus({ code: 2, message });
+                      result = `Error: ${message}`;
+                    }
+
+                    return { toolCallId: toolCall.id, result };
+                  },
+                ),
+              ),
+            );
+
+            for (const { toolCallId, result } of toolResults) {
+              loopMessages.push({ role: 'tool', content: result, toolCallId });
             }
           }
-        }
 
-        // Tool-calling iteration
-        fullText += iterationText;
-
-        if (pendingToolCalls.length === 0) {
-          break;
-        }
-
-        // Append the assistant message with tool calls
-        const assistantMessage: AiCoreMessage = {
-          role: 'assistant',
-          content: iterationText,
-          toolCalls: pendingToolCalls,
-        };
-        loopMessages.push(assistantMessage);
-
-        // Execute tool calls in parallel and append results
-        const toolResults = await Promise.all(
-          pendingToolCalls.map(async (toolCall) => {
-            const handler = toolHandlers?.[toolCall.name];
-            let result: string;
-
-            if (handler) {
-              try {
-                const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
-                result = await handler(args);
-              } catch (error) {
-                logError(`Error executing tool ${toolCall.name}:`, error);
-                result = `Error: ${error instanceof Error ? error.message : 'Tool execution failed'}`;
-              }
-            } else {
-              result = `Error: Unknown tool "${toolCall.name}"`;
-            }
-
-            return { toolCallId: toolCall.id, result };
-          }),
-        );
-
-        for (const { toolCallId, result } of toolResults) {
-          loopMessages.push({ role: 'tool', content: result, toolCallId });
-        }
-      }
+          agentSpan.setAttribute('gen_ai.usage.input_tokens', totalUsage.promptTokens);
+          agentSpan.setAttribute('gen_ai.usage.output_tokens', totalUsage.completionTokens);
+          agentSpan.setAttribute('gen_ai.usage.total_tokens', totalUsage.totalTokens);
+        },
+      );
 
       onComplete({ fullText, usage: totalUsage, priceInCents: totalPriceInCents });
     } catch (error) {

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -38,6 +38,7 @@ import { buildTools } from './build-tools';
 import { runWebSearchPipeline } from './websearch';
 import type { WebSearchResult } from '@shared/db/schema';
 import { RetrievedChunk } from '../rag/types';
+import { HELP_MODE_ASSISTANT_ID } from '@shared/db/const';
 
 /**
  * Converts frontend messages to ai-core message format
@@ -55,6 +56,24 @@ function convertToAiCoreMessages(systemPrompt: string, messages: ChatMessage[]):
   }
 
   return result;
+}
+
+function resolveAgentNameForTracing({
+  characterId,
+  learningScenarioId,
+  assistantId,
+}: {
+  characterId?: string;
+  learningScenarioId?: string;
+  assistantId?: string;
+}): string {
+  if (characterId) return 'Character';
+  if (learningScenarioId) return 'Learning Scenario';
+  if (assistantId) {
+    if (assistantId === HELP_MODE_ASSISTANT_ID) return 'Help Mode';
+    return 'Assistant';
+  }
+  return 'Chat';
 }
 
 /**
@@ -340,6 +359,8 @@ export async function sendChatMessage({
       },
     });
     webSearchResults = builtTools.webSearchResults;
+    const agentName = resolveAgentNameForTracing({ characterId, learningScenarioId, assistantId });
+
     // Start the agent loop in the background
     runAgentLoop({
       model: definedModel,
@@ -347,6 +368,7 @@ export async function sendChatMessage({
       messages: aiCoreMessages,
       tools: builtTools.tools,
       toolHandlers: builtTools.toolHandlers,
+      agentName,
       onTextChunk: (delta) => {
         update(delta);
       },

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -342,7 +342,7 @@ export async function sendChatMessage({
     webSearchResults = builtTools.webSearchResults;
     // Start the agent loop in the background
     runAgentLoop({
-      modelId: definedModel.id,
+      model: definedModel,
       apiKeyId,
       messages: aiCoreMessages,
       tools: builtTools.tools,

--- a/packages/ai-core/src/google-client.ts
+++ b/packages/ai-core/src/google-client.ts
@@ -1,6 +1,7 @@
 import type { LlmModel } from '@ais-chat/api-database';
 import { GoogleGenAI } from '@google/genai';
 import { ProviderConfigurationError } from './errors';
+import { instrumentGoogleGenAIClient } from '@sentry/core';
 
 const GOOGLE_API_VERSION = 'v1';
 const GOOGLE_CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
@@ -31,10 +32,8 @@ export function createGoogleClient(model: LlmModel): GoogleClientConfig {
     return cachedClient;
   }
 
-  const client = {
-    projectId,
-    location,
-    client: new GoogleGenAI({
+  const instrumentedClient = instrumentGoogleGenAIClient(
+    new GoogleGenAI({
       enterprise: true,
       project: projectId,
       location,
@@ -43,6 +42,12 @@ export function createGoogleClient(model: LlmModel): GoogleClientConfig {
         scopes: [GOOGLE_CLOUD_PLATFORM_SCOPE],
       },
     }),
+  );
+
+  const client = {
+    projectId,
+    location,
+    client: instrumentedClient,
   };
 
   googleClientCache.set(cacheKey, client);

--- a/packages/shared/src/sentry/server-init.ts
+++ b/packages/shared/src/sentry/server-init.ts
@@ -29,6 +29,7 @@ export function initSentry({
     debug: false,
     dsn: env.sentryDsn,
     environment: env.sentryEnvironment,
+    streamGenAiSpans: true,
     integrations: [
       Sentry.captureConsoleIntegration({ levels: ['fatal', 'error', 'warn', 'info'] }),
     ],


### PR DESCRIPTION
Wraps the agent loop, per-iteration LLM calls, and tool executions in Sentry spans following the gen_ai semantic conventions. Enables tracing of time-to-first-token, token usage, and tool call latency. Also enables streamGenAiSpans in the shared Sentry server init.