### PR TITLE
TD-1258: fix sentryTraceSampleRate typo in runtimeEnv mappings

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -45,6 +45,6 @@ export const env = createEnv({
     port: process.env.PORT,
     sentryEnvironment: process.env.SENTRY_ENVIRONMENT,
     sentryProfileSessionSampleRate: process.env.SENTRY_PROFILE_SESSION_SAMPLE_RATE,
-    sentryTraceSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
+    sentryTracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
   },
 });

--- a/packages/shared/src/sentry/env.ts
+++ b/packages/shared/src/sentry/env.ts
@@ -20,7 +20,7 @@ export const env = createEnv({
     otelMetricExportTimeout: process.env.OTEL_METRIC_EXPORT_TIMEOUT,
     sentryDsn: process.env.SENTRY_DSN,
     sentryEnvironment: process.env.SENTRY_ENVIRONMENT,
-    sentryTraceSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
-    sentryTraceSampleRateClient: process.env.SENTRY_TRACES_SAMPLE_RATE_CLIENT,
+    sentryTracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
+    sentryTracesSampleRateClient: process.env.SENTRY_TRACES_SAMPLE_RATE_CLIENT,
   },
 });


### PR DESCRIPTION
The runtimeEnv key sentryTraceSampleRate (missing 's') did not match the schema key sentryTracesSampleRate, causing SENTRY_TRACES_SAMPLE_RATE to be silently ignored.