### PR TITLE
Do not split history between tool calls and tool results

### DIFF
--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -25,11 +25,6 @@ import { constructCharacterSystemPrompt } from './system-prompt';
 import { convertToAiCoreMessages, formatMessagesWithImages, limitChatHistory } from '../chat/utils';
 import { retrieveChunks } from '../rag/rag-service';
 import { logError } from '@shared/logging';
-import {
-  KEEP_FIRST_MESSAGES,
-  KEEP_RECENT_MESSAGES,
-  TOTAL_CHAT_LENGTH_LIMIT,
-} from '@/configuration-text-inputs/const';
 import { ChatMessage, SendMessageResult, createErrorResult } from '@/types/chat';
 import { extractImagesAndUrl } from '../file-operations/preprocess-image';
 import { ingestWebContent } from '../rag/ingestWebContent';
@@ -128,12 +123,7 @@ export async function sendCharacterMessage({
   });
 
   // Prune messages
-  const prunedMessages = limitChatHistory({
-    messages: messages.map((m) => ({ id: m.id, role: m.role, content: m.content })),
-    limitRecent: KEEP_RECENT_MESSAGES,
-    limitFirst: KEEP_FIRST_MESSAGES,
-    characterLimit: TOTAL_CHAT_LENGTH_LIMIT,
-  });
+  const prunedMessages = limitChatHistory(messages);
 
   // Check if the model supports images based on supportedImageFormats
   const modelSupportsImages =

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -30,11 +30,6 @@ import {
 import { convertMessageModelToMessage } from '@/utils/chat/messages';
 import { retrieveChunks } from '../rag/rag-service';
 import { logError } from '@shared/logging';
-import {
-  KEEP_FIRST_MESSAGES,
-  KEEP_RECENT_MESSAGES,
-  TOTAL_CHAT_LENGTH_LIMIT,
-} from '@/configuration-text-inputs/const';
 import { ChatMessage, SendMessageResult, createErrorResult } from '@/types/chat';
 import { extractUrls } from '../utils/extract-urls';
 import { UserAndContext } from '@/auth/types';
@@ -310,12 +305,7 @@ export async function sendChatMessage({
   ];
 
   // Prune messages
-  const prunedMessages = limitChatHistory({
-    messages: fullMessages,
-    limitRecent: KEEP_RECENT_MESSAGES,
-    limitFirst: KEEP_FIRST_MESSAGES,
-    characterLimit: TOTAL_CHAT_LENGTH_LIMIT,
-  });
+  const prunedMessages = limitChatHistory(fullMessages);
 
   // Build system prompt
   const systemPrompt = constructChatSystemPrompt({

--- a/apps/chat-bot/src/app/api/chat/message-cutoff.test.ts
+++ b/apps/chat-bot/src/app/api/chat/message-cutoff.test.ts
@@ -9,11 +9,11 @@ function createMessage(role: 'user' | 'assistant', content: string): Message {
 }
 
 describe('limitChatHistory', () => {
-  it('should include first 2 and last 4 messages regardless of content length', () => {
+  it('should keep only the last message when character limit is very small', () => {
     // Create messages
     const messages: Message[] = [
-      createMessage('user', generateRandomString(100)), // First message
-      createMessage('assistant', generateRandomString(100)), // Second message
+      createMessage('user', generateRandomString(100)), // Will be omitted
+      createMessage('assistant', generateRandomString(100)), // Will be omitted
       createMessage('user', generateRandomString(100)), // Will be omitted
       createMessage('assistant', generateRandomString(100)), // Will be omitted
       createMessage('user', generateRandomString(100)), // Will be omitted
@@ -23,98 +23,50 @@ describe('limitChatHistory', () => {
       createMessage('user', generateRandomString(100)),
     ];
 
-    const result = limitChatHistory({
-      messages,
-      limitRecent: 2,
-      limitFirst: 1,
-      characterLimit: 300,
-    });
+    const result = limitChatHistory(messages, 300);
 
-    // Should include first 2 and last 4 messages
-    expect(result.length).toBe(6);
-    expect(result[0]?.content).toBe(messages?.[0]?.content);
-    expect(result[1]?.content).toBe(messages?.[1]?.content);
-    expect(result[2]?.content).toBe(messages?.[5]?.content);
-    expect(result[3]?.content).toBe(messages?.[6]?.content);
-    expect(result[4]?.content).toBe(messages?.[7]?.content);
-    expect(result[5]?.content).toBe(messages?.[8]?.content);
+    // Should include only the last message (all others exceed budget)
+    expect(result.length).toBe(1);
+    expect(result[0]?.content).toBe(messages[8]?.content);
   });
 
-  it('should include first and last messages without overlap', () => {
+  it('should include all messages if character limit allows it', () => {
     // Create messages
     const messages: Message[] = [
-      createMessage('user', generateRandomString(100)), // First message
-      createMessage('assistant', generateRandomString(100)), // Second message
-      createMessage('user', generateRandomString(100)), // Last message
+      createMessage('user', generateRandomString(100)),
+      createMessage('assistant', generateRandomString(100)),
+      createMessage('user', generateRandomString(100)),
       createMessage('assistant', generateRandomString(100)),
     ];
 
-    const result = limitChatHistory({
-      messages,
-      limitRecent: 2,
-      limitFirst: 1,
-      characterLimit: 300,
-    });
+    const result = limitChatHistory(messages, 500);
 
-    // Should include all messages
+    // Should include all messages since total chars fit within limit
     expect(result.length).toBe(4);
-    expect(result[0]?.content).toBe(messages?.[0]?.content);
-    expect(result[1]?.content).toBe(messages?.[1]?.content);
-    expect(result[2]?.content).toBe(messages?.[2]?.content);
-    expect(result[3]?.content).toBe(messages?.[3]?.content);
+    expect(result).toEqual(messages);
   });
 
-  it('should include most recent messages up to character limit after mandatory messages', () => {
+  it('should include most recent older messages up to character limit', () => {
     const messages: Message[] = [
-      createMessage('user', generateRandomString(100)), // First message
-      createMessage('assistant', generateRandomString(100)), // Second message
+      createMessage('user', generateRandomString(100)), // Will be omitted (too large with msg at index 3)
+      createMessage('assistant', generateRandomString(100)), // Will be omitted
       createMessage('user', generateRandomString(70)), // Will be omitted
-      createMessage('assistant', generateRandomString(1000)), // Will be omitted
-      createMessage('user', generateRandomString(50)), // Will be included
+      createMessage('assistant', generateRandomString(1000)), // Will be omitted (too large)
+      createMessage('user', generateRandomString(50)), // Will be included (fits)
       createMessage('assistant', generateRandomString(100)), // Last 4 messages
       createMessage('user', generateRandomString(100)),
       createMessage('assistant', generateRandomString(100)),
       createMessage('user', generateRandomString(100)),
     ];
 
-    const result = limitChatHistory({
-      messages,
-      limitRecent: 2,
-      limitFirst: 1,
-      characterLimit: 700,
-    });
+    const result = limitChatHistory(messages, 500);
 
-    // Should include first 2 and and the last 4 as well as other messages possible within character limit
-    expect(result.length).toBe(7);
-    expect(result[0]?.content).toBe(messages?.[0]?.content);
-    expect(result[1]?.content).toBe(messages?.[1]?.content);
-    expect(result[2]?.content).toBe(messages?.[4]?.content);
-    expect(result[3]?.content).toBe(messages?.[5]?.content);
-    expect(result[4]?.content).toBe(messages?.[6]?.content);
-    expect(result[5]?.content).toBe(messages?.[7]?.content);
-    expect(result[6]?.content).toBe(messages?.[8]?.content);
-  });
-
-  it('should include all messages if character limit allows it', () => {
-    const messages: Message[] = [
-      createMessage('user', generateRandomString(1000)), // First message
-      createMessage('assistant', generateRandomString(1000)), // Second message
-      createMessage('user', generateRandomString(1000)),
-      createMessage('assistant', generateRandomString(1000)),
-      createMessage('user', generateRandomString(1000)), // Last 4 messages
-      createMessage('assistant', generateRandomString(1000)),
-      createMessage('user', generateRandomString(1000)),
-      createMessage('assistant', generateRandomString(1000)),
-    ];
-
-    const result = limitChatHistory({
-      messages,
-      limitRecent: 2,
-      limitFirst: 1,
-      characterLimit: 10000,
-    });
-
-    expect(result.length).toBe(messages.length);
-    expect(result).toEqual(messages);
+    // Should include the most recent messages that fit within 500 chars
+    expect(result.length).toBe(5);
+    expect(result[0]?.content).toBe(messages[4]?.content);
+    expect(result[1]?.content).toBe(messages[5]?.content);
+    expect(result[2]?.content).toBe(messages[6]?.content);
+    expect(result[3]?.content).toBe(messages[7]?.content);
+    expect(result[4]?.content).toBe(messages[8]?.content);
   });
 });

--- a/apps/chat-bot/src/app/api/chat/message-cutoff.test.ts
+++ b/apps/chat-bot/src/app/api/chat/message-cutoff.test.ts
@@ -1,37 +1,120 @@
 import { describe, it, expect } from 'vitest';
-import { limitChatHistory } from './utils';
+import { limitChatHistory, groupIntoBlocks } from './utils';
 import { type ChatMessage as Message } from '@/types/chat';
 import { generateRandomString } from '../../../../e2e/utils/random';
+import { ConversationRole } from '@ais-chat/ai-core/chat/types';
 
 // Helper function to create a message
-function createMessage(role: 'user' | 'assistant', content: string): Message {
+function createMessage(role: ConversationRole, content: string): Message {
   return { role, content, id: generateRandomString(10) };
 }
 
-describe('limitChatHistory', () => {
-  it('should keep only the last message when character limit is very small', () => {
-    // Create messages
+function createToolCallMessage(content: string): Message {
+  return {
+    role: 'assistant',
+    content,
+    id: generateRandomString(10),
+    toolCalls: [{ id: 'call_1', name: 'search', arguments: '{}' }],
+  };
+}
+
+function createToolResultMessage(content: string): Message {
+  return {
+    role: 'tool',
+    content,
+    id: generateRandomString(10),
+    toolCallId: 'call_1',
+  };
+}
+
+describe('groupIntoBlocks', () => {
+  it('should group simple user/assistant pairs into blocks', () => {
     const messages: Message[] = [
-      createMessage('user', generateRandomString(100)), // Will be omitted
-      createMessage('assistant', generateRandomString(100)), // Will be omitted
-      createMessage('user', generateRandomString(100)), // Will be omitted
-      createMessage('assistant', generateRandomString(100)), // Will be omitted
-      createMessage('user', generateRandomString(100)), // Will be omitted
-      createMessage('assistant', generateRandomString(100)), // Last 4 messages
+      createMessage('user', 'hello'),
+      createMessage('assistant', 'hi'),
+      createMessage('user', 'question'),
+      createMessage('assistant', 'answer'),
+    ];
+
+    const blocks = groupIntoBlocks(messages);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0]!.messages.length).toBe(2);
+    expect(blocks[1]!.messages.length).toBe(2);
+  });
+
+  it('should keep tool call sequences in one block', () => {
+    const messages: Message[] = [
+      createMessage('user', 'search for X'),
+      createToolCallMessage(''),
+      createToolResultMessage('result data'),
+      createMessage('assistant', 'I found X'),
+    ];
+
+    const blocks = groupIntoBlocks(messages);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0]!.messages.length).toBe(4);
+  });
+
+  it('should handle conversation starting with assistant/tool messages', () => {
+    const messages: Message[] = [
+      createMessage('assistant', 'Welcome!'),
+      createMessage('user', 'hello'),
+      createMessage('assistant', 'hi there'),
+    ];
+
+    const blocks = groupIntoBlocks(messages);
+    expect(blocks.length).toBe(2);
+    // First block is the orphaned assistant message
+    expect(blocks[0]!.messages).toEqual([messages[0]]);
+    // Second block starts at the user message
+    expect(blocks[1]!.messages).toEqual(messages.slice(1));
+  });
+});
+
+describe('limitChatHistory', () => {
+  it('should return empty array for empty input', () => {
+    const result = limitChatHistory([], 1000);
+    expect(result).toEqual([]);
+  });
+
+  it('should merge consecutive same-role messages before grouping into blocks', () => {
+    // Two consecutive user messages followed by assistant — consolidation merges them
+    // into a single user message, producing one block instead of two
+    const messages: Message[] = [
+      createMessage('user', 'part 1'),
+      createMessage('user', 'part 2'),
+      createMessage('assistant', 'response'),
+      createMessage('user', 'next question'),
+      createMessage('assistant', 'next answer'),
+    ];
+
+    const result = limitChatHistory(messages, 5000);
+
+    // After consolidation: [{user: "part 1\n\npart 2"}, {assistant: "response"}, {user: ...}, {assistant: ...}]
+    // = 2 blocks, all fit within budget
+    expect(result.length).toBe(4);
+    expect(result[0]!.content).toBe('part 1\n\npart 2');
+    expect(result[1]!.content).toBe('response');
+    expect(result[2]!.content).toBe('next question');
+    expect(result[3]!.content).toBe('next answer');
+  });
+
+  it('should keep only the last block when character limit is very small', () => {
+    const messages: Message[] = [
       createMessage('user', generateRandomString(100)),
-      createMessage('assistant', generateRandomString(1000)),
+      createMessage('assistant', generateRandomString(100)),
+      createMessage('user', generateRandomString(100)),
+      createMessage('assistant', generateRandomString(100)),
       createMessage('user', generateRandomString(100)),
     ];
 
-    const result = limitChatHistory(messages, 300);
+    const result = limitChatHistory(messages, 50);
 
-    // Should include only the last message (all others exceed budget)
-    expect(result.length).toBe(1);
-    expect(result[0]?.content).toBe(messages[8]?.content);
+    // Last block is the last user message (no assistant reply yet)
+    expect(result).toEqual(messages.slice(4));
   });
 
   it('should include all messages if character limit allows it', () => {
-    // Create messages
     const messages: Message[] = [
       createMessage('user', generateRandomString(100)),
       createMessage('assistant', generateRandomString(100)),
@@ -41,32 +124,93 @@ describe('limitChatHistory', () => {
 
     const result = limitChatHistory(messages, 500);
 
-    // Should include all messages since total chars fit within limit
     expect(result.length).toBe(4);
     expect(result).toEqual(messages);
   });
 
-  it('should include most recent older messages up to character limit', () => {
+  it('should include most recent blocks up to character limit', () => {
     const messages: Message[] = [
-      createMessage('user', generateRandomString(100)), // Will be omitted (too large with msg at index 3)
-      createMessage('assistant', generateRandomString(100)), // Will be omitted
-      createMessage('user', generateRandomString(70)), // Will be omitted
-      createMessage('assistant', generateRandomString(1000)), // Will be omitted (too large)
-      createMessage('user', generateRandomString(50)), // Will be included (fits)
-      createMessage('assistant', generateRandomString(100)), // Last 4 messages
       createMessage('user', generateRandomString(100)),
-      createMessage('assistant', generateRandomString(100)),
-      createMessage('user', generateRandomString(100)),
+      createMessage('assistant', generateRandomString(1000)),
+      createMessage('user', generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
+      createMessage('user', generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
     ];
 
-    const result = limitChatHistory(messages, 500);
+    const result = limitChatHistory(messages, 250);
 
-    // Should include the most recent messages that fit within 500 chars
-    expect(result.length).toBe(5);
-    expect(result[0]?.content).toBe(messages[4]?.content);
-    expect(result[1]?.content).toBe(messages[5]?.content);
-    expect(result[2]?.content).toBe(messages[6]?.content);
-    expect(result[3]?.content).toBe(messages[7]?.content);
-    expect(result[4]?.content).toBe(messages[8]?.content);
+    // Should include last 2 blocks (50+50 + 50+50 = 200, fits in 250)
+    expect(result).toEqual(messages.slice(2));
+  });
+
+  it('should never split a tool call sequence', () => {
+    const messages: Message[] = [
+      createMessage('user', generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
+      createMessage('user', generateRandomString(50)),
+      createToolCallMessage(generateRandomString(50)),
+      createToolResultMessage(generateRandomString(200)),
+      createMessage('assistant', generateRandomString(50)),
+      createMessage('user', generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
+    ];
+
+    // Budget fits last block (100) but not the tool-call block (350)
+    const result = limitChatHistory(messages, 150);
+
+    // Should only include the last block, not split the tool-call block
+    expect(result).toEqual(messages.slice(6));
+  });
+
+  it('should include tool call block when it fits entirely', () => {
+    const messages: Message[] = [
+      createMessage('user', generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
+      createMessage('user', generateRandomString(50)),
+      createToolCallMessage(generateRandomString(50)),
+      createToolResultMessage(generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
+      createMessage('user', generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
+    ];
+
+    // Block 1: user+assistant = 100 chars
+    // Block 2: user+toolCall+toolResult+assistant = 200 chars
+    // Block 3: user+assistant = 100 chars
+    // Budget 350 fits block 3 (100) + block 2 (200) = 300
+    const result = limitChatHistory(messages, 350);
+
+    // Should include last 2 blocks (tool-call block + last block)
+    expect(result).toEqual(messages.slice(2));
+  });
+
+  it('should keep multi-step tool call sequences in one block', () => {
+    const messages: Message[] = [
+      // First tool call block (will be cut off)
+      createMessage('user', generateRandomString(50)),
+      createToolCallMessage(generateRandomString(50)),
+      createToolResultMessage(generateRandomString(200)),
+      createMessage('assistant', generateRandomString(50)),
+      // Second tool call block: user asks, model calls tool twice before responding
+      createMessage('user', generateRandomString(50)),
+      createToolCallMessage(generateRandomString(50)),
+      createToolResultMessage(generateRandomString(50)),
+      createToolCallMessage(generateRandomString(50)),
+      createToolResultMessage(generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
+      // Final simple turn
+      createMessage('user', generateRandomString(50)),
+      createMessage('assistant', generateRandomString(50)),
+    ];
+
+    // Block 1: user+toolCall+toolResult+assistant = 350 chars (too large to include)
+    // Block 2: user+toolCall+toolResult+toolCall+toolResult+assistant = 300 chars
+    // Block 3: user+assistant = 100 chars
+    // Budget 450 fits block 3 (100) + block 2 (300) = 400, but not block 1
+    const result = limitChatHistory(messages, 450);
+
+    // Should include last 2 blocks, cutting off the first tool-call block entirely
+    expect(result).toEqual(messages.slice(4));
   });
 });

--- a/apps/chat-bot/src/app/api/chat/utils.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.ts
@@ -70,9 +70,48 @@ export function consolidateMessages(messages: Array<ChatMessage>): Array<ChatMes
   return consolidatedMessages;
 }
 
+type MessageBlock = {
+  messages: ChatMessage[];
+  charCount: number;
+};
+
 /**
- * Limits chat history by keeping as many recent messages as fit within the character limit.
- * Always keeps at least the last message.
+ * Groups messages into atomic blocks, splitting at each user message.
+ * A block contains the user message and all subsequent messages until the next user message.
+ * This ensures tool call sequences (assistant with toolCalls + tool results + final response)
+ * are never split from their initiating user message.
+ */
+export function groupIntoBlocks(messages: Array<ChatMessage>): MessageBlock[] {
+  const blocks: MessageBlock[] = [];
+  let current: ChatMessage[] = [];
+
+  for (const msg of messages) {
+    // A new user message starts a new block (flush previous)
+    if (msg.role === 'user' && current.length > 0) {
+      blocks.push({
+        messages: current,
+        charCount: current.reduce((s, m) => s + m.content.length, 0),
+      });
+      current = [];
+    }
+    current.push(msg);
+  }
+
+  if (current.length > 0) {
+    blocks.push({
+      messages: current,
+      charCount: current.reduce((s, m) => s + m.content.length, 0),
+    });
+  }
+
+  return blocks;
+}
+
+/**
+ * Limits chat history by keeping as many recent message blocks as fit within the character limit.
+ * Messages are grouped into blocks at each user message, so tool call sequences are never split.
+ * Always keeps at least the last block (the most recent user message),
+ * so the model always has some input.
  *
  * @param messages - The messages to limit
  * @param characterLimit - Maximum total characters allowed
@@ -85,19 +124,22 @@ export function limitChatHistory(
   const consolidated = consolidateMessages(messages);
   if (consolidated.length === 0) return [];
 
-  // Always keep at least the last message
-  let startIndex = consolidated.length - 1;
-  let charCount = consolidated[startIndex]!.content.length;
+  const blocks = groupIntoBlocks(consolidated);
+  if (blocks.length === 0) return [];
 
-  // Include older messages while within character limit
+  // Always keep at least the last block
+  let startIndex = blocks.length - 1;
+  let charCount = blocks[startIndex]!.charCount;
+
+  // Include older blocks while within character limit
   while (startIndex > 0) {
-    const msg = consolidated[startIndex - 1]!;
-    if (charCount + msg.content.length > characterLimit) break;
-    charCount += msg.content.length;
+    const block = blocks[startIndex - 1]!;
+    if (charCount + block.charCount > characterLimit) break;
+    charCount += block.charCount;
     startIndex--;
   }
 
-  return consolidated.slice(startIndex);
+  return blocks.slice(startIndex).flatMap((b) => b.messages);
 }
 
 /**

--- a/apps/chat-bot/src/app/api/chat/utils.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.ts
@@ -2,6 +2,7 @@ import { ImageAttachment } from '@/utils/files/types';
 import { logError } from '@shared/logging';
 import { type ChatMessage } from '@/types/chat';
 import { generateTextWithBilling, type Message as AiCoreMessage } from '@ais-chat/ai-core';
+import { TOTAL_CHAT_LENGTH_LIMIT } from '@/configuration-text-inputs/const';
 
 /**
  * Format messages to include images for models that support vision
@@ -70,66 +71,33 @@ export function consolidateMessages(messages: Array<ChatMessage>): Array<ChatMes
 }
 
 /**
- * Limits chat history by keeping the first message pairs, last message pairs, and filling remaining space
- * with middle messages (prioritizing more recent ones), while respecting character limits.
+ * Limits chat history by keeping as many recent messages as fit within the character limit.
+ * Always keeps at least the last message.
  *
  * @param messages - The messages to limit
- * @param limitRecent - Number of recent message pairs to keep (e.g. 2 means 2 user + 2 assistant messages)
- * @param limitFirst - Number of first message pairs to keep (default: 2)
  * @param characterLimit - Maximum total characters allowed
- * @returns Limited message array with prioritized recent context
+ * @returns Limited message array with the most recent context that fits
  */
-export function limitChatHistory({
-  messages,
-  limitRecent,
-  limitFirst = 2,
-  characterLimit,
-}: {
-  messages: Array<ChatMessage>;
-  limitRecent: number;
-  limitFirst?: number;
-  characterLimit: number;
-}): Array<ChatMessage> {
-  const consolidatedMessages = consolidateMessages(messages);
+export function limitChatHistory(
+  messages: Array<ChatMessage>,
+  characterLimit: number = TOTAL_CHAT_LENGTH_LIMIT,
+): Array<ChatMessage> {
+  const consolidated = consolidateMessages(messages);
+  if (consolidated.length === 0) return [];
 
-  // Convert pairs to individual message counts
-  const maxFirst = limitFirst * 2;
-  const maxRecent = limitRecent * 2;
+  // Always keep at least the last message
+  let startIndex = consolidated.length - 1;
+  let charCount = consolidated[startIndex]!.content.length;
 
-  // If we have fewer messages or less characters than the limits, just return all messages
-  const totalChars = consolidatedMessages.reduce((sum, msg) => sum + msg.content.length, 0);
-  if (consolidatedMessages.length <= maxFirst + maxRecent || totalChars <= characterLimit) {
-    return consolidatedMessages;
+  // Include older messages while within character limit
+  while (startIndex > 0) {
+    const msg = consolidated[startIndex - 1]!;
+    if (charCount + msg.content.length > characterLimit) break;
+    charCount += msg.content.length;
+    startIndex--;
   }
 
-  // Get mandatory messages
-  const firstMessages = consolidatedMessages.slice(0, maxFirst);
-  const recentMessages = consolidatedMessages.slice(-maxRecent);
-
-  // Get middle messages in reverse order (most recent first)
-  const startIndex = maxFirst;
-  const endIndex = consolidatedMessages.length - maxRecent;
-  const middleMessages = consolidatedMessages.slice(startIndex, endIndex).reverse();
-
-  // Build result: first + recent, as they are mandatory
-  const result = [...firstMessages, ...recentMessages];
-  let charCount = result.reduce((sum, msg) => sum + msg.content.length, 0);
-
-  // Add middle messages that fit within the character limit
-  const middleToAdd: ChatMessage[] = [];
-  for (const msg of middleMessages) {
-    if (charCount + msg.content.length <= characterLimit) {
-      middleToAdd.unshift(msg); // Add to front to maintain chronological order
-      charCount += msg.content.length;
-    } else {
-      break;
-    }
-  }
-
-  // Insert middle messages between first and recent
-  result.splice(firstMessages.length, 0, ...middleToAdd);
-
-  return result;
+  return consolidated.slice(startIndex);
 }
 
 /**

--- a/apps/chat-bot/src/app/api/chat/utils.ts
+++ b/apps/chat-bot/src/app/api/chat/utils.ts
@@ -70,7 +70,7 @@ export function consolidateMessages(messages: Array<ChatMessage>): Array<ChatMes
   return consolidatedMessages;
 }
 
-type MessageBlock = {
+export type MessageBlock = {
   messages: ChatMessage[];
   charCount: number;
 };

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -25,11 +25,6 @@ import { constructLearningScenarioSystemPrompt } from './system-prompt';
 import { convertToAiCoreMessages, formatMessagesWithImages, limitChatHistory } from '../chat/utils';
 import { retrieveChunks } from '../rag/rag-service';
 import { logError } from '@shared/logging';
-import {
-  KEEP_FIRST_MESSAGES,
-  KEEP_RECENT_MESSAGES,
-  TOTAL_CHAT_LENGTH_LIMIT,
-} from '@/configuration-text-inputs/const';
 import { ChatMessage, SendMessageResult, createErrorResult } from '@/types/chat';
 import { extractImagesAndUrl } from '../file-operations/preprocess-image';
 import { ingestWebContent } from '../rag/ingestWebContent';
@@ -133,12 +128,7 @@ export async function sendLearningScenarioMessage({
   });
 
   // Prune messages
-  const prunedMessages = limitChatHistory({
-    messages: messages.map((m) => ({ id: m.id, role: m.role, content: m.content })),
-    limitRecent: KEEP_RECENT_MESSAGES,
-    limitFirst: KEEP_FIRST_MESSAGES,
-    characterLimit: TOTAL_CHAT_LENGTH_LIMIT,
-  });
+  const prunedMessages = limitChatHistory(messages);
 
   // Check if the model supports images based on supportedImageFormats
   const modelSupportsImages =

--- a/apps/chat-bot/src/configuration-text-inputs/const.ts
+++ b/apps/chat-bot/src/configuration-text-inputs/const.ts
@@ -3,15 +3,13 @@ export const TEXT_INPUT_FIELDS_LENGTH_LIMIT = 500;
 export const TEXT_INPUT_FIELDS_LENGTH_LIMIT_FOR_DETAILED_SETTINGS = 50_000;
 export const CHAT_MESSAGE_LENGTH_LIMIT = 6000;
 export const SMALL_TEXT_INPUT_FIELDS_LIMIT = 50;
-export const TOTAL_CHAT_LENGTH_LIMIT = 60_000; // Maximum total characters in chat history (~40 DIN A4 pages)
 
 // Web scraper
 export const WEB_SCRAPE_RESULT_LENGTH_LIMIT = 6000; // Maximum total characters from a single web scrape result (~4 DIN A4 pages)
 export const MAX_WEB_SCRAPE_RESULTS_PER_CONVERSATION = 5; // Maximum number of URLs to scrape per conversation
 
 // Chat history
-export const KEEP_RECENT_MESSAGES = 30; // Number of recent messages to keep in chat history
-export const KEEP_FIRST_MESSAGES = 2; // Number of first messages to keep in chat history
+export const TOTAL_CHAT_LENGTH_LIMIT = 60_000; // Maximum total characters in chat history (~40 DIN A4 pages)
 
 // RAG
 export const CHUNK_SIZE = 2500; // Number of characters per chunk when splitting text for RAG. Typical sweet spot to balance context richness with retrieval relevance


### PR DESCRIPTION
- simplified history condensing - just take the most recent messages that fit into the limit
- split only blocks - a block consists of a user message and consecutive non-user messages, (e.g. assistant, assistant with tool call, or tool with tool result)
- added tests to reflect the new behaviour