### PR TITLE
TD-1288: fix SessionWatcher to prevent logout on network failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,11 @@ After making any file changes:
 4. Treat issues as blocking — fix problems before finishing
 5. If verification cannot run (missing deps, env issues), clearly report that
 
+### Git Conventions
+
+- **Prefix all commits with JIRA ticket**: `TD-1234: Concise summary`
+- **Keep commit messages concise**: Short subject line, optional body if needed
+
 ## Code Conventions
 
 ### General Principles

--- a/apps/chat-bot/e2e/tests/session-network-resilience.test.ts
+++ b/apps/chat-bot/e2e/tests/session-network-resilience.test.ts
@@ -9,11 +9,11 @@ test.use({ storageState: AUTH_FILES.teacher });
  *
  * ResilientSessionProvider intercepts fetch requests to /api/auth/session and:
  * 1. Caches valid sessions
- * 2. Returns cached session on network errors or 5xx responses
+ * 2. Returns cached session on network errors or 5xx responses (transient failures)
  * 3. Keeps NextAuth in 'authenticated' state so polling continues
- * 4. Allows genuine logout (200 with null) to proceed normally
+ * 4. Allows genuine logout (200 with null) and 4xx errors to proceed normally
  *
- * SessionWatcher verifies endpoint reachability before logout redirect.
+ * SessionWatcher redirects when NextAuth reports 'unauthenticated' status.
  *
  * Expected behavior:
  * - Network failures (abort, 502, 503, etc.) → SHOULD NOT redirect (cached session used)

--- a/apps/chat-bot/e2e/tests/session-network-resilience.test.ts
+++ b/apps/chat-bot/e2e/tests/session-network-resilience.test.ts
@@ -1,0 +1,179 @@
+import { expect, test } from '@playwright/test';
+import { AUTH_FILES } from '../utils/const';
+import { focusPage } from '../utils/browser';
+
+test.use({ storageState: AUTH_FILES.teacher });
+
+/**
+ * Tests for ResilientSessionProvider and SessionWatcher resilience to network failures.
+ *
+ * ResilientSessionProvider intercepts fetch requests to /api/auth/session and:
+ * 1. Caches valid sessions
+ * 2. Returns cached session on network errors or 5xx responses
+ * 3. Keeps NextAuth in 'authenticated' state so polling continues
+ * 4. Allows genuine logout (200 with null) to proceed normally
+ *
+ * SessionWatcher verifies endpoint reachability before logout redirect.
+ *
+ * Expected behavior:
+ * - Network failures (abort, 502, 503, etc.) → SHOULD NOT redirect (cached session used)
+ * - Genuine logout (200 with null session) → SHOULD redirect to logout
+ */
+test.describe('ResilientSessionProvider and SessionWatcher', () => {
+  test('keeps session alive on network failure (user offline)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    const initialUrl = page.url();
+
+    // Simulate network failure (user offline) by aborting requests
+    await page.route('**/api/auth/session', (route) => {
+      route.abort('failed');
+    });
+
+    // Trigger refetch - should use cached session and not redirect
+    const sessionRequestPromise = page.waitForRequest('**/api/auth/session');
+    await focusPage(page);
+    await sessionRequestPromise;
+
+    // Should still be on same page, NOT redirected
+    expect(page.url()).toBe(initialUrl);
+    expect(page.url()).not.toContain('/logout');
+  });
+
+  test('keeps session alive on infrastructure error (502 Bad Gateway)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    const initialUrl = page.url();
+
+    // Simulate 502 Bad Gateway (infrastructure error)
+    await page.route('**/api/auth/session', (route) => {
+      route.fulfill({
+        status: 502,
+        contentType: 'text/html',
+        body: '<!DOCTYPE html><html><body><h1>502 Bad Gateway</h1></body></html>',
+      });
+    });
+
+    // Trigger refetch - should use cached session and not redirect
+    const sessionResponsePromise = page.waitForResponse('**/api/auth/session');
+    await focusPage(page);
+    await sessionResponsePromise;
+
+    // Should not redirect
+    expect(page.url()).toBe(initialUrl);
+    expect(page.url()).not.toContain('/logout');
+  });
+
+  test('NextAuth polling continues working with cached session', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    const initialUrl = page.url();
+
+    let requestCount = 0;
+    await page.route('**/api/auth/session', (route) => {
+      requestCount++;
+      if (requestCount === 1) {
+        // First request succeeds
+        route.continue();
+      } else {
+        // Subsequent requests fail (infrastructure down)
+        route.abort('failed');
+      }
+    });
+
+    // Wait and trigger multiple refetches via focus
+    const req1 = page.waitForRequest('**/api/auth/session');
+    await focusPage(page);
+    await req1;
+
+    const req2 = page.waitForRequest('**/api/auth/session');
+    await focusPage(page);
+    await req2;
+
+    const req3 = page.waitForRequest('**/api/auth/session');
+    await focusPage(page);
+    await req3;
+
+    // Multiple refetch attempts should have been made (polling is still active)
+    expect(requestCount).toBeGreaterThan(1);
+
+    // Should still be on same page (not logged out)
+    expect(page.url()).toBe(initialUrl);
+  });
+
+  test('triggers logout redirect on genuine session invalidation', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    let requestCount = 0;
+    // Only return null after the first request (which establishes the session)
+    await page.route('**/api/auth/session', (route) => {
+      requestCount++;
+      if (requestCount === 1) {
+        // Let first request through to establish session
+        route.continue();
+      } else {
+        // Subsequent requests: genuine logout - 200 with null session
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(null),
+        });
+      }
+    });
+
+    // Trigger refetch - this will get the null response
+    const sessionResponsePromise = page.waitForResponse('**/api/auth/session');
+    await focusPage(page);
+    await sessionResponsePromise;
+
+    // Should redirect to logout
+    await page.waitForURL(/\/(logout|login)/);
+    expect(page.url()).toMatch(/\/(logout-callback|login)/);
+  });
+
+  test('recovers when infrastructure comes back online', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    const initialUrl = page.url();
+
+    let failureCount = 0;
+    const maxFailures = 2;
+
+    await page.route('**/api/auth/session', (route) => {
+      failureCount++;
+      if (failureCount <= maxFailures) {
+        // Infrastructure down - return 502
+        route.fulfill({
+          status: 502,
+          contentType: 'text/html',
+          body: '<!DOCTYPE html><html><body><h1>502 Bad Gateway</h1></body></html>',
+        });
+      } else {
+        // Infrastructure recovered - allow normal response
+        route.continue();
+      }
+    });
+
+    // First refetch - infrastructure down, uses cache
+    const resp1 = page.waitForResponse('**/api/auth/session');
+    await focusPage(page);
+    await resp1;
+    expect(page.url()).toBe(initialUrl);
+
+    // Second refetch - still down, uses cache
+    const resp2 = page.waitForResponse('**/api/auth/session');
+    await focusPage(page);
+    await resp2;
+    expect(page.url()).toBe(initialUrl);
+
+    // Third refetch - infrastructure back, should get fresh session
+    const resp3 = page.waitForResponse('**/api/auth/session');
+    await focusPage(page);
+    await resp3;
+
+    // Should still be authenticated and on same page
+    expect(page.url()).toBe(initialUrl);
+    expect(failureCount).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/apps/chat-bot/e2e/utils/browser.ts
+++ b/apps/chat-bot/e2e/utils/browser.ts
@@ -1,0 +1,10 @@
+import { Page } from '@playwright/test';
+
+export async function focusPage(page: Page) {
+  // Manually trigger focus/visibility events to ensure refetch happens
+  const waitForSession = page.waitForRequest('**/api/auth/session');
+  await page.evaluate(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await waitForSession;
+}

--- a/apps/chat-bot/e2e/utils/browser.ts
+++ b/apps/chat-bot/e2e/utils/browser.ts
@@ -3,7 +3,9 @@ import { Page } from '@playwright/test';
 export async function focusPage(page: Page) {
   // Manually trigger focus/visibility events to ensure refetch happens
   const waitForSession = page.waitForRequest('**/api/auth/session');
+  await page.bringToFront();
   await page.evaluate(() => {
+    window.dispatchEvent(new Event('focus'));
     document.dispatchEvent(new Event('visibilitychange'));
   });
   await waitForSession;

--- a/apps/chat-bot/src/app/client-provider.tsx
+++ b/apps/chat-bot/src/app/client-provider.tsx
@@ -5,9 +5,9 @@ import { ThemeProvider } from '@/components/providers/theme-provider';
 import { DesignConfiguration } from '@ui/types/design-configuration';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Session } from 'next-auth';
-import { SessionProvider } from 'next-auth/react';
 import { ThemeProvider as NextThemeProvider } from '@ui/components/theme-provider';
 import { TooltipProvider } from '@ui/components/tooltip';
+import ResilientSessionProvider from '@/auth/ResilientSessionProvider';
 import SessionClearer from '@/auth/SessionClearer';
 
 const queryClient = new QueryClient();
@@ -32,10 +32,10 @@ export default function ClientProvider({
             disableTransitionOnChange
           >
             <ThemeProvider designConfiguration={designConfiguration}>
-              <SessionProvider session={session} refetchInterval={60} refetchOnWindowFocus>
+              <ResilientSessionProvider session={session} refetchInterval={60} refetchOnWindowFocus>
                 <SessionClearer />
                 {children}
-              </SessionProvider>
+              </ResilientSessionProvider>
             </ThemeProvider>
           </NextThemeProvider>
         </ToastProvider>

--- a/apps/chat-bot/src/auth/ResilientSessionProvider.tsx
+++ b/apps/chat-bot/src/auth/ResilientSessionProvider.tsx
@@ -28,6 +28,7 @@ export default function ResilientSessionProvider({
 }: ResilientSessionProviderProps) {
   const lastValidSessionRef = useRef<Session | null>(session);
   const originalFetchRef = useRef<typeof fetch | null>(null);
+  const wrappedFetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
     // Store original fetch if not already stored
@@ -41,7 +42,7 @@ export default function ResilientSessionProvider({
     }
 
     // Intercept fetch for session endpoint
-    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const wrappedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 
       // Only intercept session endpoint requests (exact match on pathname)
@@ -78,20 +79,21 @@ export default function ResilientSessionProvider({
           return response;
         }
 
-        // Non-OK response (4xx, 5xx) - infrastructure error
-        logWarning('Session endpoint returned error status - using cached session', {
-          status: response.status,
-        });
-
-        if (lastValidSessionRef.current) {
-          // Return cached session to prevent logout
-          return new Response(JSON.stringify(lastValidSessionRef.current), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
+        // 5xx response - transient infrastructure error
+        if (response.status >= 500) {
+          logWarning('Session endpoint returned server error - using cached session', {
+            status: response.status,
           });
+
+          if (lastValidSessionRef.current) {
+            return new Response(JSON.stringify(lastValidSessionRef.current), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
         }
 
-        // No cached session - allow the error
+        // 4xx or no cached session - allow the error to propagate
         return response;
       } catch (error) {
         // Network error (fetch failed)
@@ -110,9 +112,12 @@ export default function ResilientSessionProvider({
       }
     };
 
-    // Cleanup: restore original fetch on unmount
+    wrappedFetchRef.current = wrappedFetch;
+    window.fetch = wrappedFetch;
+
+    // Cleanup: restore original fetch only if window.fetch is still our wrapper
     return () => {
-      if (originalFetchRef.current) {
+      if (originalFetchRef.current && window.fetch === wrappedFetchRef.current) {
         window.fetch = originalFetchRef.current;
       }
     };

--- a/apps/chat-bot/src/auth/ResilientSessionProvider.tsx
+++ b/apps/chat-bot/src/auth/ResilientSessionProvider.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+import { useEffect, useRef } from 'react';
+import { logDebug, logError, logWarning } from '@shared/logging';
+import type { Session } from 'next-auth';
+
+type ResilientSessionProviderProps = {
+  children: React.ReactNode;
+  session: Session | null;
+  refetchInterval?: number;
+  refetchOnWindowFocus?: boolean;
+};
+
+/**
+ * Wrapper around NextAuth's SessionProvider that intercepts session fetch
+ * requests and caches the last valid session to prevent logout on network errors.
+ *
+ * When the session endpoint fails (network error, 5xx), returns the cached
+ * session instead of null, keeping NextAuth in 'authenticated' state so its
+ * internal polling continues working.
+ */
+export default function ResilientSessionProvider({
+  children,
+  session,
+  refetchInterval,
+  refetchOnWindowFocus,
+}: ResilientSessionProviderProps) {
+  const lastValidSessionRef = useRef<Session | null>(session);
+  const originalFetchRef = useRef<typeof fetch | null>(null);
+
+  useEffect(() => {
+    // Store original fetch if not already stored
+    if (!originalFetchRef.current) {
+      originalFetchRef.current = window.fetch;
+    }
+
+    const originalFetch = originalFetchRef.current;
+    if (!originalFetch) {
+      throw new Error('ResilientSessionProvider: original fetch not available');
+    }
+
+    // Intercept fetch for session endpoint
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+      // Only intercept session endpoint requests (exact match on pathname)
+      const SESSION_ENDPOINT = '/api/auth/session';
+      const isSessionEndpoint =
+        url === SESSION_ENDPOINT ||
+        new URL(url, window.location.origin).pathname === SESSION_ENDPOINT;
+
+      if (!isSessionEndpoint) {
+        return originalFetch(input, init);
+      }
+
+      try {
+        const response = await originalFetch(input, init);
+
+        // If successful, parse and cache the session
+        if (response.ok) {
+          const clonedResponse = response.clone();
+          try {
+            const data = await clonedResponse.json();
+
+            if (data && typeof data === 'object' && Object.keys(data).length > 0) {
+              // Valid session - cache it
+              lastValidSessionRef.current = data as Session;
+              logDebug('Session fetched successfully - cached');
+            } else {
+              // Genuine logout (empty session) - clear cache
+              lastValidSessionRef.current = null;
+              logDebug('Session cleared (genuine logout)');
+            }
+          } catch {
+            // JSON parse error - ignore
+          }
+          return response;
+        }
+
+        // Non-OK response (4xx, 5xx) - infrastructure error
+        logWarning('Session endpoint returned error status - using cached session', {
+          status: response.status,
+        });
+
+        if (lastValidSessionRef.current) {
+          // Return cached session to prevent logout
+          return new Response(JSON.stringify(lastValidSessionRef.current), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        // No cached session - allow the error
+        return response;
+      } catch (error) {
+        // Network error (fetch failed)
+        logError('Session endpoint unreachable - using cached session', error);
+
+        if (lastValidSessionRef.current) {
+          // Return cached session to prevent logout
+          return new Response(JSON.stringify(lastValidSessionRef.current), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        // No cached session - rethrow error
+        throw error;
+      }
+    };
+
+    // Cleanup: restore original fetch on unmount
+    return () => {
+      if (originalFetchRef.current) {
+        window.fetch = originalFetchRef.current;
+      }
+    };
+  }, []);
+
+  return (
+    <SessionProvider
+      session={session}
+      refetchInterval={refetchInterval}
+      refetchOnWindowFocus={refetchOnWindowFocus}
+    >
+      {children}
+    </SessionProvider>
+  );
+}

--- a/apps/chat-bot/src/auth/ResilientSessionProvider.tsx
+++ b/apps/chat-bot/src/auth/ResilientSessionProvider.tsx
@@ -2,8 +2,10 @@
 
 import { SessionProvider } from 'next-auth/react';
 import { useEffect, useRef } from 'react';
-import { logDebug, logError, logWarning } from '@shared/logging';
+import { logDebug, logWarning } from '@shared/logging';
 import type { Session } from 'next-auth';
+
+const SESSION_ENDPOINT = '/api/auth/session';
 
 type ResilientSessionProviderProps = {
   children: React.ReactNode;
@@ -46,7 +48,6 @@ export default function ResilientSessionProvider({
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 
       // Only intercept session endpoint requests (exact match on pathname)
-      const SESSION_ENDPOINT = '/api/auth/session';
       const isSessionEndpoint =
         url === SESSION_ENDPOINT ||
         new URL(url, window.location.origin).pathname === SESSION_ENDPOINT;
@@ -97,7 +98,7 @@ export default function ResilientSessionProvider({
         return response;
       } catch (error) {
         // Network error (fetch failed)
-        logError('Session endpoint unreachable - using cached session', error);
+        logWarning('Session endpoint unreachable - using cached session', { error });
 
         if (lastValidSessionRef.current) {
           // Return cached session to prevent logout


### PR DESCRIPTION
This pull request introduces a new `ResilientSessionProvider` to prevent unwanted user logouts in the chat-bot app when the session endpoint is unavailable due to network or infrastructure errors. It ensures that the application uses a cached session during transient failures, only logging out users on genuine session invalidation. The PR also adds comprehensive end-to-end tests to verify this resilience.