### PR TITLE
Allow backend to sample traces rejected by parent

### DIFF
--- a/packages/shared/src/sentry/server-init.ts
+++ b/packages/shared/src/sentry/server-init.ts
@@ -53,11 +53,18 @@ export function initSentry({
         return 0;
       }
 
-      if (aiServerActionNameSet.has(name)) {
-        return inheritOrSampleWith(env.sentryTracesSampleRateAi);
+      // If parent was sampled, honor that decision
+      const parentSamplingDecision = inheritOrSampleWith(0);
+      if (parentSamplingDecision) {
+        return true;
       }
 
-      return inheritOrSampleWith(env.sentryTracesSampleRate);
+      // Parent was not sampled or absent, use backend's own sampling rates
+      if (aiServerActionNameSet.has(name)) {
+        return env.sentryTracesSampleRateAi;
+      }
+
+      return env.sentryTracesSampleRate;
     },
     ...(scrubSensitiveData && {
       beforeBreadcrumb: (breadcrumb) => scrubSentryEvent(breadcrumb),


### PR DESCRIPTION
Honor parent's positive sampling decisions to maintain trace continuity, but apply backend's own sampling rate when parent rejected sampling. This enables higher backend sampling rates for better observability.