### PR TITLE
feat: replace translation function with typesafe ReturnType<typeof useTranslations>

### DIFF
--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/assistant-overview.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/assistant-overview.tsx
@@ -44,7 +44,7 @@ export default function AssistantOverview({ currentUserId }: AssistantOverviewPr
   } = useOverviewFilters({
     entityType: 'assistants',
     onLoad: fetchAssistants,
-    translateFilterLabel: (key) => tCommon(key as never),
+    translateFilterLabel: tCommon,
   });
 
   async function handleFilterChange(filter: OverviewFilter) {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/editor/[assistantId]/assistant-edit.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/editor/[assistantId]/assistant-edit.tsx
@@ -7,7 +7,16 @@ import {
   TEXT_INPUT_FIELDS_LENGTH_LIMIT_FOR_DETAILED_SETTINGS,
 } from '@/configuration-text-inputs/const';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { AssistantSelectModel, FileModel } from '@shared/db/schema';
+import {
+  AssistantSelectModel,
+  FileModel,
+  schoolTypesSchema,
+  gradeRangesSchema,
+  subjectsSchema,
+  categoriesSchema,
+  federalStatesSchema,
+  languagesSchema,
+} from '@shared/db/schema';
 import { BackButton } from '@/components/common/back-button';
 import { Card, CardContent } from '@ui/components/card';
 import { FieldGroup } from '@ui/components/field';
@@ -55,7 +64,7 @@ import {
 import FilterSelectSection from '@/components/custom-chat/custom-chat-filter/custom-chat-filter-select-section';
 import {
   extractFilterValues,
-  tofilterGroup,
+  toFilterGroup,
 } from '@/components/custom-chat/custom-chat-filter/custom-chat-filter-utils';
 
 type AssistantTranslator = ReturnType<typeof useTranslations<'assistants'>>;
@@ -93,12 +102,12 @@ function createAssistantFormValuesSchema(t: AssistantTranslator) {
     name: z.string().trim().min(1, t('name-required')).max(SMALL_TEXT_INPUT_FIELDS_LIMIT),
     description: z.string(),
     instructions: z.string(),
-    schoolTypes: z.array(z.string()),
-    gradeRanges: z.array(z.string()),
-    subjects: z.array(z.string()),
-    categories: z.array(z.string()),
-    federalStates: z.array(z.string()),
-    languages: z.array(z.string()),
+    schoolTypes: z.array(schoolTypesSchema),
+    gradeRanges: z.array(gradeRangesSchema),
+    subjects: z.array(subjectsSchema),
+    categories: z.array(categoriesSchema),
+    federalStates: z.array(federalStatesSchema),
+    languages: z.array(languagesSchema),
     isSchoolShared: z.boolean(),
     isCommunityShared: z.boolean(),
     hasLinkAccess: z.boolean(),
@@ -189,7 +198,7 @@ export function AssistantEdit({
           name: data.name.trim(),
           description: data.description,
           instructions: data.instructions,
-          filterGroup: tofilterGroup({
+          filterGroup: toFilterGroup({
             schoolTypes: data.schoolTypes,
             gradeRanges: data.gradeRanges,
             subjects: data.subjects,

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/character-overview.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/character-overview.tsx
@@ -44,7 +44,7 @@ export default function CharacterOverview({ currentUserId }: CharacterOverviewPr
   } = useOverviewFilters({
     entityType: 'characters',
     onLoad: fetchCharacters,
-    translateFilterLabel: (key) => tCommon(key as never),
+    translateFilterLabel: tCommon,
   });
 
   async function handleFilterChange(filter: OverviewFilter) {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/character-edit.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/character-edit.tsx
@@ -3,7 +3,16 @@
 import z from 'zod';
 import { CustomChatLayoutContainer } from '@/components/custom-chat/custom-chat-layout-container';
 import { CustomChatTitle } from '@/components/custom-chat/custom-chat-title';
-import { CharacterOptionalShareDataModel, FileModel } from '@shared/db/schema';
+import {
+  CharacterOptionalShareDataModel,
+  FileModel,
+  schoolTypesSchema,
+  gradeRangesSchema,
+  subjectsSchema,
+  categoriesSchema,
+  federalStatesSchema,
+  languagesSchema,
+} from '@shared/db/schema';
 import { WebSource } from '@shared/db/types';
 import { useTranslations } from 'next-intl';
 import { useForceReloadOnBrowserBackButton } from '@/hooks/use-force-reload-on-browser-back-button';
@@ -63,7 +72,7 @@ import {
 import FilterSelectSection from '@/components/custom-chat/custom-chat-filter/custom-chat-filter-select-section';
 import {
   extractFilterValues,
-  tofilterGroup,
+  toFilterGroup,
 } from '@/components/custom-chat/custom-chat-filter/custom-chat-filter-utils';
 
 type CharacterTranslator = ReturnType<typeof useTranslations<'characters'>>;
@@ -105,12 +114,12 @@ function createCharacterFormValuesSchema(t: CharacterTranslator) {
     instructions: z.string(),
     initialMessage: z.string(),
     modelId: z.string(),
-    schoolTypes: z.array(z.string()),
-    gradeRanges: z.array(z.string()),
-    subjects: z.array(z.string()),
-    categories: z.array(z.string()),
-    federalStates: z.array(z.string()),
-    languages: z.array(z.string()),
+    schoolTypes: z.array(schoolTypesSchema),
+    gradeRanges: z.array(gradeRangesSchema),
+    subjects: z.array(subjectsSchema),
+    categories: z.array(categoriesSchema),
+    federalStates: z.array(federalStatesSchema),
+    languages: z.array(languagesSchema),
     isSchoolShared: z.boolean(),
     isCommunityShared: z.boolean(),
     hasLinkAccess: z.boolean(),
@@ -190,7 +199,7 @@ export function CharacterEdit({
           instructions: data.instructions,
           initialMessage: data.initialMessage,
           modelId: data.modelId,
-          filterGroup: tofilterGroup({
+          filterGroup: toFilterGroup({
             schoolTypes: data.schoolTypes,
             gradeRanges: data.gradeRanges,
             subjects: data.subjects,

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/learning-scenario-edit.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/learning-scenario-edit.tsx
@@ -6,7 +6,16 @@ import {
   TEXT_INPUT_FIELDS_LENGTH_LIMIT_FOR_DETAILED_SETTINGS,
 } from '@/configuration-text-inputs/const';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { FileModel, LearningScenarioOptionalShareDataModel } from '@shared/db/schema';
+import {
+  FileModel,
+  LearningScenarioOptionalShareDataModel,
+  schoolTypesSchema,
+  gradeRangesSchema,
+  subjectsSchema,
+  categoriesSchema,
+  federalStatesSchema,
+  languagesSchema,
+} from '@shared/db/schema';
 import { BackButton } from '@/components/common/back-button';
 import { Card, CardContent } from '@ui/components/card';
 import { FieldGroup } from '@ui/components/field';
@@ -62,7 +71,7 @@ import { CustomChatActionUse } from '@/components/custom-chat/custom-chat-action
 import FilterSelectSection from '@/components/custom-chat/custom-chat-filter/custom-chat-filter-select-section';
 import {
   extractFilterValues,
-  tofilterGroup,
+  toFilterGroup,
 } from '@/components/custom-chat/custom-chat-filter/custom-chat-filter-utils';
 
 type LearningScenarioTranslator = ReturnType<typeof useTranslations<'learning-scenarios'>>;
@@ -104,12 +113,12 @@ function createLearningScenarioFormValuesSchema(t: LearningScenarioTranslator) {
     additionalInstructions: z.string(),
     studentExercise: z.string(),
     modelId: z.string(),
-    schoolTypes: z.array(z.string()),
-    gradeRanges: z.array(z.string()),
-    subjects: z.array(z.string()),
-    categories: z.array(z.string()),
-    federalStates: z.array(z.string()),
-    languages: z.array(z.string()),
+    schoolTypes: z.array(schoolTypesSchema),
+    gradeRanges: z.array(gradeRangesSchema),
+    subjects: z.array(subjectsSchema),
+    categories: z.array(categoriesSchema),
+    federalStates: z.array(federalStatesSchema),
+    languages: z.array(languagesSchema),
     isSchoolShared: z.boolean(),
     isCommunityShared: z.boolean(),
     hasLinkAccess: z.boolean(),
@@ -195,7 +204,7 @@ export function LearningScenarioEdit({
             name: data.name.trim(),
             description: data.description ?? '',
             studentExercise: data.studentExercise ?? '',
-            filterGroup: tofilterGroup({
+            filterGroup: toFilterGroup({
               schoolTypes: data.schoolTypes,
               gradeRanges: data.gradeRanges,
               subjects: data.subjects,

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/learning-scenario-overview.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/learning-scenario-overview.tsx
@@ -46,7 +46,7 @@ export default function LearningScenarioOverview({ currentUserId }: LearningScen
   } = useOverviewFilters({
     entityType: 'learning-scenarios',
     onLoad: fetchLearningScenarios,
-    translateFilterLabel: (key) => tCommon(key as never),
+    translateFilterLabel: tCommon,
   });
 
   async function handleFilterChange(filter: OverviewFilter) {

--- a/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-display-section.tsx
+++ b/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-display-section.tsx
@@ -24,7 +24,7 @@ const FILTER_GROUP_LABELS: Record<keyof FilterValues, string> = {
 export function FilterDisplaySection({ values }: FilterDisplaySectionProps) {
   const t = useTranslations();
 
-  const pills = getActiveFilterPills(values, (key) => t(key as never));
+  const pills = getActiveFilterPills(values, t);
 
   if (pills.length === 0) {
     return null;

--- a/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-keys.ts
+++ b/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-keys.ts
@@ -13,12 +13,12 @@ import {
   ethicsSubjects,
 } from '@shared/db/schema';
 
-export const SCHOOL_TYPE_KEYS = Object.values(schoolTypesSchema.enum);
-export const GRADE_RANGE_KEYS = Object.values(gradeRangesSchema.enum);
-export const CATEGORY_KEYS = Object.values(categoriesSchema.enum);
-export const FEDERAL_STATE_KEYS = Object.values(federalStatesSchema.enum);
-export const LANGUAGE_KEYS = Object.values(languagesSchema.enum);
-export const SUBJECT_KEYS = Object.values(subjectsSchema.enum);
+export const SCHOOL_TYPE_KEYS = schoolTypesSchema.options;
+export const GRADE_RANGE_KEYS = gradeRangesSchema.options;
+export const CATEGORY_KEYS = categoriesSchema.options;
+export const FEDERAL_STATE_KEYS = federalStatesSchema.options;
+export const LANGUAGE_KEYS = languagesSchema.options;
+export const SUBJECT_KEYS = subjectsSchema.options;
 
 export const SUBJECT_SUBGROUPS = [
   {

--- a/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-select-section.tsx
+++ b/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-select-section.tsx
@@ -15,24 +15,32 @@ import {
 } from './custom-chat-filter-keys';
 import { CustomChatHeading2 } from '../custom-chat-heading2';
 import { cn } from '@ui/lib/utils';
+import type {
+  SchoolType,
+  GradeRange,
+  Subject,
+  Category,
+  FederalState,
+  Language,
+} from '@shared/db/schema';
 
 export type FilterSelectSectionValues = {
-  schoolTypes: string[];
-  gradeRanges: string[];
-  subjects: string[];
-  categories: string[];
-  federalStates: string[];
-  languages: string[];
+  schoolTypes: SchoolType[];
+  gradeRanges: GradeRange[];
+  subjects: Subject[];
+  categories: Category[];
+  federalStates: FederalState[];
+  languages: Language[];
 };
 
 type FilterSelectSectionProps = {
   values: FilterSelectSectionValues;
-  onSchoolTypesChange: (values: string[]) => void;
-  onGradeRangesChange: (values: string[]) => void;
-  onSubjectsChange: (values: string[]) => void;
-  onCategoriesChange: (values: string[]) => void;
-  onFederalStatesChange: (values: string[]) => void;
-  onLanguagesChange: (values: string[]) => void;
+  onSchoolTypesChange: (values: SchoolType[]) => void;
+  onGradeRangesChange: (values: GradeRange[]) => void;
+  onSubjectsChange: (values: Subject[]) => void;
+  onCategoriesChange: (values: Category[]) => void;
+  onFederalStatesChange: (values: FederalState[]) => void;
+  onLanguagesChange: (values: Language[]) => void;
   hideHeading?: boolean;
   isEditView?: boolean;
   onReset?: () => void;

--- a/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-utils.ts
+++ b/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-utils.ts
@@ -119,7 +119,7 @@ export function toFilterGroup(values: FilterValues): filterGroup {
 export type ActiveFilterPill = {
   label: string;
   group: keyof FilterValues;
-  value: string;
+  value: FilterValues[keyof FilterValues][number];
 };
 
 export function getActiveFilterPills(

--- a/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-utils.ts
+++ b/apps/chat-bot/src/components/custom-chat/custom-chat-filter/custom-chat-filter-utils.ts
@@ -7,14 +7,15 @@ import {
   type FederalState,
   type Language,
 } from '@shared/db/schema';
+import { useTranslations } from 'next-intl';
 
 export type FilterValues = {
-  schoolTypes: string[];
-  gradeRanges: string[];
-  subjects: string[];
-  categories: string[];
-  federalStates: string[];
-  languages: string[];
+  schoolTypes: SchoolType[];
+  gradeRanges: GradeRange[];
+  subjects: Subject[];
+  categories: Category[];
+  federalStates: FederalState[];
+  languages: Language[];
 };
 
 export const EMPTY_FILTER_VALUES: FilterValues = {
@@ -28,23 +29,23 @@ export const EMPTY_FILTER_VALUES: FilterValues = {
 
 type EntityWithFilterValues = {
   filterGroup?: {
-    school_types?: string[];
-    grade_ranges?: string[];
-    subjects?: string[];
-    categories?: string[];
-    federal_states?: string[];
-    languages?: string[];
+    school_types?: SchoolType[];
+    grade_ranges?: GradeRange[];
+    subjects?: Subject[];
+    categories?: Category[];
+    federal_states?: FederalState[];
+    languages?: Language[];
   };
-  schoolType?: string | null;
-  gradeLevel?: string | null;
-  subject?: string | null;
+  schoolType?: SchoolType | null;
+  gradeLevel?: GradeRange | null;
+  subject?: Subject | null;
 };
 
-function unique(values: string[]): string[] {
+function unique<T>(values: T[]): T[] {
   return [...new Set(values)];
 }
 
-function matchesSelectedGroup(entityValues: string[], selectedValues: string[]): boolean {
+function matchesSelectedGroup<T>(entityValues: T[], selectedValues: T[]): boolean {
   if (selectedValues.length === 0) {
     return true;
   }
@@ -104,14 +105,14 @@ export function extractFilterValues(entity: EntityWithFilterValues): FilterValue
   };
 }
 
-export function tofilterGroup(values: FilterValues): filterGroup {
+export function toFilterGroup(values: FilterValues): filterGroup {
   return {
-    school_types: unique(values.schoolTypes) as SchoolType[],
-    grade_ranges: unique(values.gradeRanges) as GradeRange[],
-    subjects: unique(values.subjects) as Subject[],
-    categories: unique(values.categories) as Category[],
-    federal_states: unique(values.federalStates) as FederalState[],
-    languages: unique(values.languages) as Language[],
+    school_types: unique(values.schoolTypes),
+    grade_ranges: unique(values.gradeRanges),
+    subjects: unique(values.subjects),
+    categories: unique(values.categories),
+    federal_states: unique(values.federalStates),
+    languages: unique(values.languages),
   };
 }
 
@@ -123,7 +124,7 @@ export type ActiveFilterPill = {
 
 export function getActiveFilterPills(
   values: FilterValues,
-  t: (key: string) => string,
+  t: ReturnType<typeof useTranslations<never>>,
 ): ActiveFilterPill[] {
   return [
     ...values.schoolTypes.map((value) => ({
@@ -161,7 +162,7 @@ export function getActiveFilterPills(
 
 export function getActiveFilterPillLabels(
   values: FilterValues,
-  t: (key: string) => string,
+  t: ReturnType<typeof useTranslations<never>>,
 ): string[] {
   return getActiveFilterPills(values, t).map((pill) => pill.label);
 }

--- a/apps/chat-bot/src/components/hooks/use-overview-filters.ts
+++ b/apps/chat-bot/src/components/hooks/use-overview-filters.ts
@@ -12,11 +12,12 @@ import {
   type EntityType,
   usePersistedOverviewFilter,
 } from '@/components/hooks/use-persisted-overview-filter';
+import { useTranslations } from 'next-intl';
 
 type UseOverviewFiltersOptions = {
   entityType: EntityType;
   onLoad: (filter: OverviewFilter) => Promise<void>;
-  translateFilterLabel: (key: string) => string;
+  translateFilterLabel: ReturnType<typeof useTranslations<never>>;
 };
 
 type UseOverviewFiltersResult = {

--- a/packages/ui/src/components/multiple-select-dropdown.tsx
+++ b/packages/ui/src/components/multiple-select-dropdown.tsx
@@ -6,24 +6,24 @@ import { Checkbox } from './checkbox';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from './dropdown-menu';
 import { Field, FieldLabel } from './field';
 
-export type MultipleSelectDropdownoptionGroups = {
+export type MultipleSelectDropdownoptionGroups<T extends string = string> = {
   title?: string;
-  options: Array<{ value: string; label: string }>;
+  options: Array<{ value: T; label: string }>;
 };
 
-type MultipleSelectDropdownProps = {
+type MultipleSelectDropdownProps<T extends string = string> = {
   label: string;
   tooltip?: string;
-  value: string[];
-  onValueChange: (values: string[]) => void;
-  optionGroups: MultipleSelectDropdownoptionGroups[];
+  value: T[];
+  onValueChange: (values: T[]) => void;
+  optionGroups: MultipleSelectDropdownoptionGroups<T>[];
   placeholder?: string;
   testId: string;
   selectedCountLabel?: (count: number) => string;
   contentClassName?: string;
 };
 
-export function MultipleSelectDropdown({
+export function MultipleSelectDropdown<T extends string = string>({
   label,
   tooltip,
   value,
@@ -33,7 +33,7 @@ export function MultipleSelectDropdown({
   testId,
   selectedCountLabel,
   contentClassName,
-}: MultipleSelectDropdownProps) {
+}: MultipleSelectDropdownProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const options = useMemo(() => optionGroups.flatMap((group) => group.options), [optionGroups]);
 
@@ -50,7 +50,7 @@ export function MultipleSelectDropdown({
     return selectedCountLabel?.(value.length) ?? String(value.length);
   }, [options, placeholder, selectedCountLabel, value]);
 
-  const toggleValue = (optionValue: string) => {
+  const toggleValue = (optionValue: T) => {
     if (value.includes(optionValue)) {
       onValueChange(value.filter((selectedValue) => selectedValue !== optionValue));
       return;

--- a/packages/ui/src/components/multiple-select-dropdown.tsx
+++ b/packages/ui/src/components/multiple-select-dropdown.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from './checkbox';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from './dropdown-menu';
 import { Field, FieldLabel } from './field';
 
-export type MultipleSelectDropdownoptionGroups<T extends string = string> = {
+export type MultipleSelectDropdownOptionGroup<T extends string = string> = {
   title?: string;
   options: Array<{ value: T; label: string }>;
 };
@@ -16,7 +16,7 @@ type MultipleSelectDropdownProps<T extends string = string> = {
   tooltip?: string;
   value: T[];
   onValueChange: (values: T[]) => void;
-  optionGroups: MultipleSelectDropdownoptionGroups<T>[];
+  optionGroups: MultipleSelectDropdownOptionGroup<T>[];
   placeholder?: string;
   testId: string;
   selectedCountLabel?: (count: number) => string;


### PR DESCRIPTION
- Replace `t: (key: string) => string` with `t: ReturnType<typeof useTranslations<never>>`
- Use proper enum types (SchoolType[], GradeRange[], etc.) in FilterValues instead of string[]
- Update form schemas to use zod enum schemas (schoolTypesSchema, gradeRangesSchema, etc.)
- Make MultipleSelectDropdown generic to support string literal types without casts
- Use schema.options instead of Object.values(schema.enum) for proper type inference
- Rename tofilterGroup to toFilterGroup (proper camelCase)
- Remove all type casts - full type inference from component props