### PR TITLE
test: add Drizzle migration journal validation

### DIFF
--- a/packages/api-database/package.json
+++ b/packages/api-database/package.json
@@ -17,6 +17,9 @@
     "db:seed": "dotenv -e ../../apps/api/.env.local -- tsx src/seed.ts",
     "db:seed:from-stage": "dotenv -e ../../apps/api/.env.local -- tsx src/seed-from-stage.ts",
     "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
     "types": "tsc --noEmit"
   },
   "dependencies": {
@@ -33,10 +36,12 @@
     "@ais-chat/typescript-config": "workspace:*",
     "@types/node": "24.13.2",
     "@types/pg": "8.20.0",
+    "@vitest/coverage-v8": "4.1.8",
     "dotenv-cli": "11.0.0",
     "drizzle-kit": "0.31.10",
     "eslint": "9.39.4",
     "tsx": "4.22.4",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "4.1.8"
   }
 }

--- a/packages/api-database/src/journal.test.ts
+++ b/packages/api-database/src/journal.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type DrizzleMigrationJournal = {
+  entries: Array<{
+    idx: number;
+    when: number;
+  }>;
+};
+
+/**
+ * Tests for Drizzle migration journal validation
+ *
+ * Drizzle ORM < 1.0.0 uses a "high water mark" approach - it tracks the highest migration
+ * timestamp applied and skips migrations with earlier timestamps. If parallel branches create
+ * migrations with non-ascending timestamps, some migrations will be silently skipped after merge.
+ *
+ * This test can be removed after upgrading to Drizzle ORM 1.0.0, which fixes the ordering logic.
+ */
+describe('Drizzle Migration Journal - API Database', () => {
+  test('should have strictly ascending idx and timestamps', () => {
+    const journalPath = resolve(__dirname, '../migrations/meta/_journal.json');
+    const journalContent = readFileSync(journalPath, 'utf-8');
+    const journal = JSON.parse(journalContent) as DrizzleMigrationJournal;
+
+    for (let i = 1; i < journal.entries.length; i++) {
+      const currentEntry = journal.entries[i]!;
+      const prevEntry = journal.entries[i - 1]!;
+
+      expect
+        .soft(
+          currentEntry.idx,
+          `idx at position ${i} (${currentEntry.idx}) must be > ${prevEntry.idx}`,
+        )
+        .toBeGreaterThan(prevEntry.idx);
+      expect
+        .soft(
+          currentEntry.when,
+          `timestamp at position ${i} (${currentEntry.when}) must be > ${prevEntry.when}`,
+        )
+        .toBeGreaterThan(prevEntry.when);
+    }
+  });
+});

--- a/packages/api-database/src/journal.test.ts
+++ b/packages/api-database/src/journal.test.ts
@@ -12,7 +12,7 @@ type DrizzleMigrationJournal = {
 /**
  * Tests for Drizzle migration journal validation
  *
- * Drizzle ORM < 1.0.0 uses a "high water mark" approach - it tracks the highest migration
+ * Drizzle ORM < 1.0.0 uses a "high water mark" approach - it tracks the most recent migration
  * timestamp applied and skips migrations with earlier timestamps. If parallel branches create
  * migrations with non-ascending timestamps, some migrations will be silently skipped after merge.
  *

--- a/packages/api-database/vitest.config.ts
+++ b/packages/api-database/vitest.config.ts
@@ -1,0 +1,25 @@
+import { coverageConfigDefaults, defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@/': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    include: ['**/*.{test,spec}.{js,ts,jsx,tsx}'],
+
+    exclude: ['**/node_modules/**', '**/dist/**', '**/e2e/**'],
+
+    environment: 'node',
+
+    testTimeout: 5000,
+
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'json', 'html'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/e2e/**', ...coverageConfigDefaults.exclude],
+    },
+  },
+});

--- a/packages/shared/src/db/journal.test.ts
+++ b/packages/shared/src/db/journal.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type DrizzleMigrationJournal = {
+  entries: Array<{
+    idx: number;
+    when: number;
+  }>;
+};
+
+/**
+ * Tests for Drizzle migration journal validation
+ *
+ * Drizzle ORM < 1.0.0 uses a "high water mark" approach - it tracks the highest migration
+ * timestamp applied and skips migrations with earlier timestamps. If parallel branches create
+ * migrations with non-ascending timestamps, some migrations will be silently skipped after merge.
+ *
+ * This test can be removed after upgrading to Drizzle ORM 1.0.0, which fixes the ordering logic.
+ */
+describe('Drizzle Migration Journal - Shared Database', () => {
+  test('should have strictly ascending idx and timestamps', () => {
+    const journalPath = resolve(__dirname, '../../migrations/meta/_journal.json');
+    const journalContent = readFileSync(journalPath, 'utf-8');
+    const journal = JSON.parse(journalContent) as DrizzleMigrationJournal;
+
+    for (let i = 1; i < journal.entries.length; i++) {
+      const currentEntry = journal.entries[i]!;
+      const prevEntry = journal.entries[i - 1]!;
+
+      expect
+        .soft(
+          currentEntry.idx,
+          `idx at position ${i} (${currentEntry.idx}) must be > ${prevEntry.idx}`,
+        )
+        .toBeGreaterThan(prevEntry.idx);
+      expect
+        .soft(
+          currentEntry.when,
+          `timestamp at position ${i} (${currentEntry.when}) must be > ${prevEntry.when}`,
+        )
+        .toBeGreaterThan(prevEntry.when);
+    }
+  });
+});

--- a/packages/shared/src/db/journal.test.ts
+++ b/packages/shared/src/db/journal.test.ts
@@ -12,7 +12,7 @@ type DrizzleMigrationJournal = {
 /**
  * Tests for Drizzle migration journal validation
  *
- * Drizzle ORM < 1.0.0 uses a "high water mark" approach - it tracks the highest migration
+ * Drizzle ORM < 1.0.0 uses a "high water mark" approach - it tracks the most recent migration
  * timestamp applied and skips migrations with earlier timestamps. If parallel branches create
  * migrations with non-ascending timestamps, some migrations will be silently skipped after merge.
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,9 @@ importers:
       '@types/pg':
         specifier: 8.20.0
         version: 8.20.0
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       dotenv-cli:
         specifier: 11.0.0
         version: 11.0.0
@@ -674,6 +677,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/eslint-config:
     dependencies:


### PR DESCRIPTION
Verify migration journal entries have strictly ascending idx and timestamps to prevent silent migration skips in Drizzle ORM < 1.0.0.

Can be removed after upgrading to Drizzle ORM 1.0.0.