### PR TITLE
TD-1364: enable Next.js graceful shutdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,12 @@ After making any file changes:
 - **Prefix all commits with JIRA ticket**: `TD-1234: Concise summary`
 - **Keep commit messages concise**: Short subject line, optional body if needed
 
+## Pull Requests
+
+- Write concise PR descriptions: 1-3 short paragraphs explaining what changed and why.
+- Avoid formal section headings; keep it simple and direct.
+- PRs must always be opened as draft
+
 ## Code Conventions
 
 ### General Principles

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -3,6 +3,11 @@ import * as Sentry from '@sentry/nextjs';
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('./instrumentation.node');
+
+    const { registerCleanupHandler } = await import('@shared/shutdown/cleanup');
+    const { shutdownDatabase } = await import('@shared/db');
+
+    registerCleanupHandler(shutdownDatabase);
   }
 }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/node';
 import buildApp from './app';
 import { env } from './env';
 import path from 'node:path';
-import { db, migrateWithLock } from '@ais-chat/api-database';
+import { db, migrateWithLock, shutdownDatabase } from '@ais-chat/api-database';
 import { logger } from './logger';
 
 async function runDatabaseMigration() {
@@ -41,6 +41,7 @@ async function main() {
     fastify.gracefulShutdown(async () => {
       await shutdownTracing();
       await flushSentry();
+      await shutdownDatabase();
     });
   });
 

--- a/apps/chat-bot/src/rabbitmq/send.ts
+++ b/apps/chat-bot/src/rabbitmq/send.ts
@@ -21,3 +21,9 @@ export async function sendRabbitmqEvent(event: object) {
     span.end();
   });
 }
+
+export async function shutdownRabbitMQ() {
+  console.log('[shutdown] Closing RabbitMQ connection...');
+  await rabbit.close();
+  console.log('[shutdown] RabbitMQ connection closed');
+}

--- a/apps/chat-bot/src/startup.ts
+++ b/apps/chat-bot/src/startup.ts
@@ -1,4 +1,4 @@
-import { runDatabaseMigration } from '@shared/db';
+import { runDatabaseMigration, shutdownDatabase } from '@shared/db';
 import { dbGetFederalStates, dbUpdateFederalState } from '@shared/db/functions/federal-state';
 import { decrypt } from '@shared/db/crypto';
 import { env } from '@shared/env';
@@ -6,6 +6,8 @@ import { env as aiEnv } from '@ais-chat/ai-core/env';
 import { lookupApiKeys } from '@ais-chat/ai-core/api-keys/lookup';
 import { logError, logInfo } from '@shared/logging';
 import { listFilesFromS3 } from '@shared/s3';
+import { registerCleanupHandler } from '@shared/shutdown/cleanup';
+import { shutdownRabbitMQ } from '@/rabbitmq/send';
 
 /**
  * Custom code that will be executed on application startup.
@@ -13,6 +15,9 @@ import { listFilesFromS3 } from '@shared/s3';
 export async function startup() {
   await runDatabaseMigration();
   await postMigration();
+
+  registerCleanupHandler(shutdownDatabase);
+  registerCleanupHandler(shutdownRabbitMQ);
 }
 
 /**

--- a/packages/api-database/src/index.ts
+++ b/packages/api-database/src/index.ts
@@ -20,6 +20,12 @@ if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
 
 export const db = drizzle({ client: pool });
 
+export async function shutdownDatabase() {
+  console.log('[shutdown] Closing database connection pool...');
+  await pool.end();
+  console.log('[shutdown] Database connection pool closed');
+}
+
 export * from './schema';
 export * from './functions';
 export * from './types';

--- a/packages/shared/src/db/index.ts
+++ b/packages/shared/src/db/index.ts
@@ -33,6 +33,12 @@ export const db = drizzle({
     : undefined,
 });
 
+export async function shutdownDatabase() {
+  console.log('[shutdown] Closing PostgreSQL connection pool...');
+  await pool.end();
+  console.log('[shutdown] PostgreSQL connection pool closed');
+}
+
 export async function runDatabaseMigration() {
   try {
     logInfo('Running database migrations...');

--- a/packages/shared/src/sentry/server-init.ts
+++ b/packages/shared/src/sentry/server-init.ts
@@ -9,6 +9,7 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { SentrySampler, SentrySpanProcessor } from '@sentry/opentelemetry';
 import { scrubSentryEvent } from '@ais-chat/shared-core/sentry/scrub';
+import { registerCleanupHandler } from '../shutdown/cleanup';
 import { env } from './env';
 
 /**
@@ -113,14 +114,11 @@ export function initSentry({
 
   sdk.start();
 
-  // gracefully shut down the SDK on process exit
-  process.on('SIGTERM', () => {
-    sdk
-      .shutdown()
-      .then(() => console.log('Tracing terminated'))
-      .catch((error) => console.log('Error terminating tracing', error))
-      .finally(() => process.exit(0));
-  });
-
   Sentry.validateOpenTelemetrySetup();
+
+  registerCleanupHandler(async () => {
+    console.log('[shutdown] Shutting down OpenTelemetry SDK...');
+    await sdk.shutdown();
+    console.log('[shutdown] OpenTelemetry SDK shutdown completed');
+  });
 }

--- a/packages/shared/src/shutdown/cleanup.ts
+++ b/packages/shared/src/shutdown/cleanup.ts
@@ -1,0 +1,59 @@
+/*
+ * Chosen approach: Cooperative shutdown with Next.js
+ *
+ * Benefits:
+ * - Leverages Next.js's shutdown logic (connection draining, trace flush)
+ * - Minimal code changes
+ * - Next.js's internal process.exit() prevents indefinite hangs
+ *
+ * Trade-off: Small race condition remains (cleanup may not complete before Next.js exits)
+ * Acceptable because cleanup typically completes quickly and Next.js prevents worst-case hangs.
+ *
+ * Alternative considered: NEXT_MANUAL_SIG_HANDLE=true for full shutdown control.
+ * Not used because it requires reimplementing Next.js shutdown logic and may break on framework upgrades.
+ *
+ * Note: console.log is used for shutdown logging because remote logging (Sentry/OpenTelemetry)
+ * may not be available during shutdown.
+ */
+
+const cleanupHandlers: Array<() => Promise<void>> = [];
+let handlersRegistered = false;
+let cleanupInProgress = false;
+
+/**
+ * Register a cleanup handler for graceful shutdown on SIGTERM/SIGINT.
+ */
+export function registerCleanupHandler(handler: () => Promise<void>): void {
+  cleanupHandlers.push(handler);
+
+  if (!handlersRegistered) {
+    handlersRegistered = true;
+
+    const executeCleanup = async (signal: 'SIGTERM' | 'SIGINT') => {
+      if (cleanupInProgress) return;
+      cleanupInProgress = true;
+
+      console.log(`[shutdown] Received ${signal}, starting resource cleanup...`);
+
+      const results = await Promise.allSettled(
+        cleanupHandlers.map(async (handler, index) => {
+          try {
+            await handler();
+          } catch (error) {
+            console.error(`[shutdown] Cleanup handler ${index} failed:`, error);
+          }
+        }),
+      );
+
+      const failed = results.filter((r) => r.status === 'rejected').length;
+      if (failed > 0) {
+        console.error(`[shutdown] ${failed} cleanup handler(s) failed`);
+      } else {
+        console.log('[shutdown] Resource cleanup completed successfully');
+      }
+    };
+
+    process.once('SIGTERM', () => void executeCleanup('SIGTERM'));
+    process.once('SIGINT', () => void executeCleanup('SIGINT'));
+  }
+}

--- a/packages/shared/src/shutdown/cleanup.ts
+++ b/packages/shared/src/shutdown/cleanup.ts
@@ -35,15 +35,13 @@ export function registerCleanupHandler(handler: () => Promise<void>): void {
 
       console.log(`[shutdown] Received ${signal}, starting resource cleanup...`);
 
-      const results = await Promise.allSettled(
-        cleanupHandlers.map(async (handler, index) => {
-          try {
-            await handler();
-          } catch (error) {
-            console.error(`[shutdown] Cleanup handler ${index} failed:`, error);
-          }
-        }),
-      );
+      const results = await Promise.allSettled(cleanupHandlers.map((handler) => handler()));
+
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          console.error(`[shutdown] Cleanup handler ${index} failed:`, result.reason);
+        }
+      });
 
       const failed = results.filter((r) => r.status === 'rejected').length;
       if (failed > 0) {


### PR DESCRIPTION
Enable Next.js graceful shutdown to prevent 5xx errors during Kubernetes deployments.

OpenTelemetry's SIGTERM handler called process.exit(0), bypassing Next.js connection draining.

Remove process.exit(0) and add cleanup handlers for OpenTelemetry SDK, PostgreSQL pools, and RabbitMQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)