### PR TITLE
TD-1376: restore Sentry instrumentation to agent loop

### DIFF
--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -37,6 +37,7 @@ import { ChatMessage, SendMessageResult, createErrorResult } from '@/types/chat'
 import { createImageAttachmentsForConversation } from '../file-operations/preprocess-image';
 import { ingestWebContent } from '../rag/ingestWebContent';
 import { RetrievedChunk } from '../rag/types';
+import { resolveAgentNameForTracing } from '../utils/agent-name';
 
 /**
  * Sends a character chat message and streams the response.
@@ -189,11 +190,15 @@ export async function sendCharacterMessage({
   const assistantMessageId = crypto.randomUUID();
 
   if (agenticChatEnabled) {
+    const agentName = resolveAgentNameForTracing({ characterId: character.id });
+
     runAgentLoop({
       modelId: definedModel.id,
+      modelName: definedModel.name,
       apiKeyId,
       messages: aiCoreMessages,
       toolRegistry,
+      agentName,
       onTextChunk: (delta) => {
         update(delta);
       },

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -54,6 +54,7 @@ import { getCharacterForChatSession } from '@shared/characters/character-service
 import { getLearningScenarioForChatSession } from '@shared/learning-scenarios/learning-scenario-service';
 import { getAssistantForNewChat } from '@shared/assistants/assistant-service';
 import { deepEqual } from '@/utils/object';
+import { resolveAgentNameForTracing } from '../utils/agent-name';
 
 // Exports for testing
 export { handleRegenerationProcessing, prepareMessageForProcessing };
@@ -573,12 +574,16 @@ export async function sendChatMessage({
   }
 
   if (agenticChatEnabled) {
+    const agentName = resolveAgentNameForTracing({ characterId, learningScenarioId, assistantId });
+
     // Start the agent loop in the background
     runAgentLoop({
       modelId: definedModel.id,
+      modelName: definedModel.name,
       apiKeyId,
       messages: aiCoreMessages,
       toolRegistry,
+      agentName,
       onTextChunk: (delta: string) => {
         update(delta);
       },

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -37,6 +37,7 @@ import { ChatMessage, SendMessageResult, createErrorResult } from '@/types/chat'
 import { createImageAttachmentsForConversation } from '../file-operations/preprocess-image';
 import { ingestWebContent } from '../rag/ingestWebContent';
 import { RetrievedChunk } from '../rag/types';
+import { resolveAgentNameForTracing } from '../utils/agent-name';
 
 /**
  * Server Action to send a learning scenario message and stream the response.
@@ -192,11 +193,15 @@ export async function sendLearningScenarioMessage({
   const assistantMessageId = crypto.randomUUID();
 
   if (agenticChatEnabled) {
+    const agentName = resolveAgentNameForTracing({ learningScenarioId: learningScenario.id });
+
     runAgentLoop({
       modelId: definedModel.id,
+      modelName: definedModel.name,
       apiKeyId,
       messages: convertToAiCoreMessages(systemPrompt, messagesWithImages),
       toolRegistry,
+      agentName,
       onTextChunk: (delta) => {
         update(delta);
       },

--- a/apps/chat-bot/src/app/api/utils/agent-name.ts
+++ b/apps/chat-bot/src/app/api/utils/agent-name.ts
@@ -1,0 +1,19 @@
+import { HELP_MODE_ASSISTANT_ID } from '@shared/db/const';
+
+export function resolveAgentNameForTracing({
+  characterId,
+  learningScenarioId,
+  assistantId,
+}: {
+  characterId?: string;
+  learningScenarioId?: string;
+  assistantId?: string;
+}): string {
+  if (characterId) return 'Character';
+  if (learningScenarioId) return 'Learning Scenario';
+  if (assistantId) {
+    if (assistantId === HELP_MODE_ASSISTANT_ID) return 'Help Mode';
+    return 'Assistant';
+  }
+  return 'Chat';
+}

--- a/packages/ai-core/src/chat/agent-loop.test.ts
+++ b/packages/ai-core/src/chat/agent-loop.test.ts
@@ -10,7 +10,20 @@ vi.mock('./index', () => ({
     mockGenerateAgenticStreamWithBilling(...args),
 }));
 
+// Mock Sentry to verify spans are created
+const mockStartSpan = vi.fn((options, callback) => callback({ setAttribute: vi.fn() }));
+
+vi.mock('@sentry/core', () => ({
+  startSpan: (options: unknown, callback: unknown) => mockStartSpan(options, callback),
+}));
+
 describe('agent-loop', () => {
+  const usage: TokenUsage = {
+    promptTokens: 10,
+    completionTokens: 20,
+    totalTokens: 30,
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -20,12 +33,6 @@ describe('agent-loop', () => {
     const onTextChunk = vi.fn();
     const onComplete = vi.fn();
     const onError = vi.fn();
-
-    const usage: TokenUsage = {
-      promptTokens: 10,
-      completionTokens: 20,
-      totalTokens: 30,
-    };
 
     // Iteration 1: produces text "Hello world." then a tool call
     // Iteration 2: produces text "More info." with no tool calls
@@ -62,9 +69,11 @@ describe('agent-loop', () => {
 
     runAgentLoop({
       modelId: 'test-model',
+      modelName: 'Test Model',
       apiKeyId: 'test-key',
       messages,
       toolRegistry,
+      agentName: 'Test Agent',
       onTextChunk,
       onComplete,
       onError,
@@ -95,12 +104,6 @@ describe('agent-loop', () => {
     const onComplete = vi.fn();
     const onError = vi.fn();
 
-    const usage: TokenUsage = {
-      promptTokens: 10,
-      completionTokens: 20,
-      totalTokens: 30,
-    };
-
     // Single iteration with no tool calls
     mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
       yield { type: 'text', delta: 'Single response.' } satisfies StreamEvent;
@@ -109,8 +112,10 @@ describe('agent-loop', () => {
 
     runAgentLoop({
       modelId: 'test-model',
+      modelName: 'Test Model',
       apiKeyId: 'test-key',
       messages,
+      agentName: 'Test Agent',
       onTextChunk,
       onComplete,
       onError,
@@ -137,12 +142,6 @@ describe('agent-loop', () => {
     const onTextChunk = vi.fn();
     const onComplete = vi.fn();
     const onError = vi.fn();
-
-    const usage: TokenUsage = {
-      promptTokens: 10,
-      completionTokens: 20,
-      totalTokens: 30,
-    };
 
     // Iteration 1: tool call only, no text
     // Iteration 2: produces text
@@ -174,9 +173,11 @@ describe('agent-loop', () => {
 
     runAgentLoop({
       modelId: 'test-model',
+      modelName: 'Test Model',
       apiKeyId: 'test-key',
       messages,
       toolRegistry,
+      agentName: 'Test Agent',
       onTextChunk,
       onComplete,
       onError,
@@ -203,12 +204,6 @@ describe('agent-loop', () => {
     const onTextChunk = vi.fn();
     const onComplete = vi.fn();
     const onError = vi.fn();
-
-    const usage: TokenUsage = {
-      promptTokens: 10,
-      completionTokens: 20,
-      totalTokens: 30,
-    };
 
     // Iteration 1: produces text ending with \n\n, then a tool call
     // Iteration 2: produces text
@@ -241,9 +236,11 @@ describe('agent-loop', () => {
 
     runAgentLoop({
       modelId: 'test-model',
+      modelName: 'Test Model',
       apiKeyId: 'test-key',
       messages,
       toolRegistry,
+      agentName: 'Test Agent',
       onTextChunk,
       onComplete,
       onError,
@@ -271,12 +268,6 @@ describe('agent-loop', () => {
     const onTextChunk = vi.fn();
     const onComplete = vi.fn();
     const onError = vi.fn();
-
-    const usage: TokenUsage = {
-      promptTokens: 10,
-      completionTokens: 20,
-      totalTokens: 30,
-    };
 
     // Three iterations, each producing text and a tool call (except the last)
     let callCount = 0;
@@ -311,9 +302,11 @@ describe('agent-loop', () => {
 
     runAgentLoop({
       modelId: 'test-model',
+      modelName: 'Test Model',
       apiKeyId: 'test-key',
       messages,
       toolRegistry,
+      agentName: 'Test Agent',
       onTextChunk,
       onComplete,
       onError,
@@ -333,5 +326,146 @@ describe('agent-loop', () => {
         fullText: 'First.\n\nSecond.\n\nThird.',
       }),
     );
+  });
+
+  describe('Sentry instrumentation', () => {
+    it('creates Sentry span for agent invocation', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onTextChunk = vi.fn();
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        yield { type: 'text', delta: 'Response' } satisfies StreamEvent;
+        yield { type: 'finish', usage } satisfies StreamEvent;
+      });
+
+      runAgentLoop({
+        modelId: 'test-model',
+        modelName: 'Test Model',
+        apiKeyId: 'test-key',
+        messages,
+        agentName: 'Test Agent',
+        onTextChunk,
+        onComplete,
+        onError,
+      });
+
+      await expect.poll(() => onComplete.mock.calls.length).toBeGreaterThan(0);
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(mockStartSpan).toHaveBeenCalledWith(
+        expect.objectContaining({ op: 'gen_ai.invoke_agent' }),
+        expect.any(Function),
+      );
+    });
+
+    it('creates Sentry spans for tool executions', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onTextChunk = vi.fn();
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        yield {
+          type: 'tool_call',
+          call: { id: 'call_1', name: 'test_tool', arguments: '{}' },
+        } satisfies StreamEvent;
+        yield { type: 'finish', usage } satisfies StreamEvent;
+      });
+
+      const toolRegistry = {
+        test_tool: {
+          definition: { name: 'test_tool', description: 'Test', parameters: {} },
+          handler: async () => 'result',
+        },
+      };
+
+      runAgentLoop({
+        modelId: 'test-model',
+        modelName: 'Test Model',
+        apiKeyId: 'test-key',
+        messages,
+        toolRegistry,
+        agentName: 'Test Agent',
+        onTextChunk,
+        onComplete,
+        onError,
+      });
+
+      await expect.poll(() => onComplete.mock.calls.length).toBeGreaterThan(0);
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(mockStartSpan).toHaveBeenCalledWith(
+        expect.objectContaining({ op: 'gen_ai.execute_tool' }),
+        expect.any(Function),
+      );
+    });
+
+    it('creates correct number of Sentry spans for multiple tool calls', async () => {
+      const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+      const onTextChunk = vi.fn();
+      const onComplete = vi.fn();
+      const onError = vi.fn();
+
+      let callCount = 0;
+      mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        callCount++;
+        if (callCount === 1) {
+          yield {
+            type: 'tool_call',
+            call: { id: 'call_1', name: 'tool1', arguments: '{}' },
+          } satisfies StreamEvent;
+          yield {
+            type: 'tool_call',
+            call: { id: 'call_2', name: 'tool2', arguments: '{}' },
+          } satisfies StreamEvent;
+          yield { type: 'finish', usage } satisfies StreamEvent;
+        } else {
+          yield { type: 'text', delta: 'Done' } satisfies StreamEvent;
+          yield { type: 'finish', usage } satisfies StreamEvent;
+        }
+      });
+
+      const toolRegistry = {
+        tool1: {
+          definition: { name: 'tool1', description: '', parameters: {} },
+          handler: async () => 'r1',
+        },
+        tool2: {
+          definition: { name: 'tool2', description: '', parameters: {} },
+          handler: async () => 'r2',
+        },
+      };
+
+      runAgentLoop({
+        modelId: 'test-model',
+        modelName: 'Test Model',
+        apiKeyId: 'test-key',
+        messages,
+        toolRegistry,
+        agentName: 'Test Agent',
+        onTextChunk,
+        onComplete,
+        onError,
+      });
+
+      await expect.poll(() => onComplete.mock.calls.length).toBeGreaterThan(0);
+
+      expect(onError).not.toHaveBeenCalled();
+
+      // Verify: 1 agent span + 2 tool spans = 3 total
+      expect(mockStartSpan).toHaveBeenCalledTimes(3);
+
+      const agentSpanCalls = mockStartSpan.mock.calls.filter(
+        (call) => call[0]?.op === 'gen_ai.invoke_agent',
+      );
+      const toolSpanCalls = mockStartSpan.mock.calls.filter(
+        (call) => call[0]?.op === 'gen_ai.execute_tool',
+      );
+
+      expect(agentSpanCalls).toHaveLength(1);
+      expect(toolSpanCalls).toHaveLength(2);
+    });
   });
 });

--- a/packages/ai-core/src/chat/agent-loop.test.ts
+++ b/packages/ai-core/src/chat/agent-loop.test.ts
@@ -351,7 +351,7 @@ describe('agent-loop', () => {
         onError,
       });
 
-      await expect.poll(() => onComplete.mock.calls.length).toBeGreaterThan(0);
+      await expect.poll(() => onComplete).toHaveBeenCalled();
 
       expect(onError).not.toHaveBeenCalled();
       expect(mockStartSpan).toHaveBeenCalledWith(
@@ -393,7 +393,7 @@ describe('agent-loop', () => {
         onError,
       });
 
-      await expect.poll(() => onComplete.mock.calls.length).toBeGreaterThan(0);
+      await expect.poll(() => onComplete).toHaveBeenCalled();
 
       expect(onError).not.toHaveBeenCalled();
       expect(mockStartSpan).toHaveBeenCalledWith(
@@ -450,7 +450,7 @@ describe('agent-loop', () => {
         onError,
       });
 
-      await expect.poll(() => onComplete.mock.calls.length).toBeGreaterThan(0);
+      await expect.poll(() => onComplete).toHaveBeenCalled();
 
       expect(onError).not.toHaveBeenCalled();
 

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/core';
 import type { Message as AiCoreMessage, TokenUsage, ToolCall, ToolRegistry } from './types';
 
 export const MAX_AGENTIC_ITERATIONS = 3;
@@ -9,9 +10,11 @@ function logError(message: string, error: unknown) {
 
 type RunAgentLoopParams = {
   modelId: string;
+  modelName: string;
   apiKeyId: string;
   messages: AiCoreMessage[];
   toolRegistry?: ToolRegistry;
+  agentName: string;
   onTextChunk: (delta: string) => void;
   onComplete: (result: {
     fullText: string;
@@ -24,9 +27,11 @@ type RunAgentLoopParams = {
 
 export function runAgentLoop({
   modelId,
+  modelName,
   apiKeyId,
   messages,
   toolRegistry,
+  agentName,
   onTextChunk,
   onComplete,
   onError,
@@ -41,81 +46,117 @@ export function runAgentLoop({
     const tools = toolRegistry ? Object.values(toolRegistry).map((entry) => entry.definition) : [];
 
     try {
-      for (let iteration = 0; iteration < MAX_AGENTIC_ITERATIONS; iteration++) {
-        const pendingToolCalls: ToolCall[] = [];
-        let iterationText = '';
-
-        // Add separator before starting a new iteration if the previous iteration produced text
-        if (iteration > 0 && fullText && !fullText.endsWith('\n\n')) {
-          fullText += '\n\n';
-          onTextChunk('\n\n');
-        }
-
-        const isLastIteration = iteration === MAX_AGENTIC_ITERATIONS - 1;
-        const stream = generateAgenticStreamWithBilling(
-          modelId,
-          loopMessages,
-          apiKeyId,
-          async ({ usage, priceInCents }) => {
-            totalUsage = {
-              promptTokens: totalUsage.promptTokens + usage.promptTokens,
-              completionTokens: totalUsage.completionTokens + usage.completionTokens,
-              totalTokens: totalUsage.totalTokens + usage.totalTokens,
-            };
-            totalPriceInCents += priceInCents;
+      await Sentry.startSpan(
+        {
+          op: 'gen_ai.invoke_agent',
+          name: `invoke_agent ${agentName}`,
+          attributes: {
+            'gen_ai.operation.name': 'invoke_agent',
+            'gen_ai.operation.type': 'agent',
+            'gen_ai.request.model': modelName,
+            'gen_ai.agent.name': agentName,
           },
-          tools.length > 0 && !isLastIteration ? { tools, toolChoice: 'auto' } : undefined,
-        );
+        },
+        async (agentSpan) => {
+          for (let iteration = 0; iteration < MAX_AGENTIC_ITERATIONS; iteration++) {
+            const pendingToolCalls: ToolCall[] = [];
+            let iterationText = '';
 
-        for await (const event of stream) {
-          if (event.type === 'text') {
-            iterationText += event.delta;
-            onTextChunk(event.delta);
-          } else if (
-            event.type === 'tool_call' &&
-            pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION
-          ) {
-            pendingToolCalls.push(event.call);
-          }
-        }
-
-        fullText += iterationText;
-
-        if (pendingToolCalls.length === 0) {
-          break;
-        }
-
-        loopMessages.push({
-          role: 'assistant',
-          content: iterationText,
-          toolCalls: pendingToolCalls,
-        });
-
-        const toolResults = await Promise.all(
-          pendingToolCalls.map(async (toolCall) => {
-            const registryEntry = toolRegistry?.[toolCall.name];
-            let result: string;
-
-            if (registryEntry) {
-              try {
-                const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
-                result = await registryEntry.handler(args);
-              } catch (error) {
-                logError(`Error executing tool ${toolCall.name}:`, error);
-                result = `Error: ${error instanceof Error ? error.message : 'Tool execution failed'}`;
-              }
-            } else {
-              result = `Error: Unknown tool "${toolCall.name}"`;
+            // Add separator before starting a new iteration if the previous iteration produced text
+            if (iteration > 0 && fullText && !fullText.endsWith('\n\n')) {
+              fullText += '\n\n';
+              onTextChunk('\n\n');
             }
 
-            return { toolCallId: toolCall.id, result };
-          }),
-        );
+            const isLastIteration = iteration === MAX_AGENTIC_ITERATIONS - 1;
+            const stream = generateAgenticStreamWithBilling(
+              modelId,
+              loopMessages,
+              apiKeyId,
+              async ({ usage, priceInCents }) => {
+                totalUsage = {
+                  promptTokens: totalUsage.promptTokens + usage.promptTokens,
+                  completionTokens: totalUsage.completionTokens + usage.completionTokens,
+                  totalTokens: totalUsage.totalTokens + usage.totalTokens,
+                };
+                totalPriceInCents += priceInCents;
+              },
+              tools.length > 0 && !isLastIteration ? { tools, toolChoice: 'auto' } : undefined,
+            );
 
-        for (const { toolCallId, result } of toolResults) {
-          loopMessages.push({ role: 'tool', content: result, toolCallId });
-        }
-      }
+            for await (const event of stream) {
+              if (event.type === 'text') {
+                iterationText += event.delta;
+                onTextChunk(event.delta);
+              } else if (
+                event.type === 'tool_call' &&
+                pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION
+              ) {
+                pendingToolCalls.push(event.call);
+              }
+            }
+
+            fullText += iterationText;
+
+            if (pendingToolCalls.length === 0) {
+              break;
+            }
+
+            loopMessages.push({
+              role: 'assistant',
+              content: iterationText,
+              toolCalls: pendingToolCalls,
+            });
+
+            const toolResults = await Promise.all(
+              pendingToolCalls.map((toolCall) =>
+                Sentry.startSpan(
+                  {
+                    op: 'gen_ai.execute_tool',
+                    name: `execute_tool ${toolCall.name}`,
+                    attributes: {
+                      'gen_ai.operation.name': 'execute_tool',
+                      'gen_ai.operation.type': 'tool',
+                      'gen_ai.tool.name': toolCall.name,
+                    },
+                  },
+                  async (toolSpan) => {
+                    const registryEntry = toolRegistry?.[toolCall.name];
+                    let result: string;
+
+                    if (registryEntry) {
+                      try {
+                        const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
+                        result = await registryEntry.handler(args);
+                      } catch (error) {
+                        const message =
+                          error instanceof Error ? error.message : 'Tool execution failed';
+                        toolSpan.setStatus({ code: 2, message });
+                        logError(`Error executing tool ${toolCall.name}:`, error);
+                        result = `Error: ${message}`;
+                      }
+                    } else {
+                      const message = `Unknown tool "${toolCall.name}"`;
+                      toolSpan.setStatus({ code: 2, message });
+                      result = `Error: ${message}`;
+                    }
+
+                    return { toolCallId: toolCall.id, result };
+                  },
+                ),
+              ),
+            );
+
+            for (const { toolCallId, result } of toolResults) {
+              loopMessages.push({ role: 'tool', content: result, toolCallId });
+            }
+          }
+
+          agentSpan.setAttribute('gen_ai.usage.input_tokens', totalUsage.promptTokens);
+          agentSpan.setAttribute('gen_ai.usage.output_tokens', totalUsage.completionTokens);
+          agentSpan.setAttribute('gen_ai.usage.total_tokens', totalUsage.totalTokens);
+        },
+      );
 
       onComplete({
         fullText,

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -129,6 +129,7 @@ export function runAgentLoop({
                         const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
                         result = await registryEntry.handler(args);
                       } catch (error) {
+                        // TODO: the catch clause is usually never executed, because tool handlers return errors as plain string or in the 'error' key of a stringified json
                         const message =
                           error instanceof Error ? error.message : 'Tool execution failed';
                         toolSpan.setStatus({ code: 2, message });

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -129,7 +129,7 @@ export function runAgentLoop({
                         const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
                         result = await registryEntry.handler(args);
                       } catch (error) {
-                        // TODO: the catch clause is usually never executed, because tool handlers return errors as plain string or in the 'error' key of a stringified json
+                        // TODO: see tech debt (refactoring of tool calls for error handling). The catch clause is usually never executed, because tool handlers return errors as plain string or in the 'error' key of a stringified json
                         const message =
                           error instanceof Error ? error.message : 'Tool execution failed';
                         toolSpan.setStatus({ code: 2, message });


### PR DESCRIPTION
Restores Sentry spans that were removed during agent-loop refactoring in commit 38c55b4f. Adds comprehensive unit tests to prevent future removal.

## Changes
- Add Sentry.startSpan wrapper for agent invocations (gen_ai.invoke_agent)
- Add Sentry.startSpan for tool executions (gen_ai.execute_tool)
- Add 3 unit tests verifying span creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)