### PR TITLE
TD-1379: handle over-budget tool calls and improve agentic output

### DIFF
--- a/apps/chat-bot/src/app/api/utils/system-prompt.ts
+++ b/apps/chat-bot/src/app/api/utils/system-prompt.ts
@@ -61,12 +61,13 @@ function constructAgenticBudgetGuidelines(): string {
   return `## Agentic loop budget
 - After every user message, you start a fresh agentic loop with a budget of up to ${MAX_AGENTIC_ITERATIONS} iterations, each allowing up to ${MAX_TOOL_CALLS_PER_ITERATION} tool calls. The budget resets on every new user message and does not carry over between messages.
 - Plan tool use across iterations within the current user message. Do not try to solve everything in a single iteration.
-- On the final iteration of the loop tool calls are disabled, so you must produce the final answer based on the information you already have.`;
+- On the final iteration of the loop tool calls are disabled, so you must produce the final answer based on the information you already have.
+- Your thinking process or internal notes do not belong in the visible output. Only produce user-facing content.`;
 }
 
 export const FORMAT_GUIDELINES = `
 ## Formatierung
-- Antworten werden als Markdown gerendert (GitHub-Flavored Markdown, Codeblöcke, Mathematik in LaTeX/KaTeX). Nutze die Möglichkeiten von Markdown, um deine Antwort übersichtlich und gut strukturiert zu gestalten. 
+- Antworten werden als Markdown gerendert (GitHub-Flavored Markdown, Codeblöcke, Mathematik in LaTeX/KaTeX). Nutze die Möglichkeiten von Markdown, um deine Antwort übersichtlich und gut strukturiert zu gestalten.
 - Nutze immer die passende Formatierung für technische Elemente, z.B. Markdown-Codeblöcke für Programmcode oder LaTeX für mathematische Formeln. Verwende in LaTeX-Formeln für natürlichsprachigen Text immer \\text{}. Benutze außerhalb von \\text{} nur Standard-LaTeX-Befehle.
 - Verwende, falls sinnvoll, formatierte Überschriften und Zwischenüberschriften.
 - Hebe wichtige Begriffe oder Kernaussagen **fett** hervor.

--- a/packages/ai-core/src/chat/agent-loop.test.ts
+++ b/packages/ai-core/src/chat/agent-loop.test.ts
@@ -328,6 +328,102 @@ describe('agent-loop', () => {
     );
   });
 
+  it('returns error responses for over-budget tool calls', async () => {
+    const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+    const onTextChunk = vi.fn();
+    const onComplete = vi.fn();
+    const onError = vi.fn();
+
+    // Iteration 1: Emit 4 tool calls (exceeds MAX_TOOL_CALLS_PER_ITERATION = 2)
+    // Iteration 2: Return final text with no more tool calls
+    let callCount = 0;
+    mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+      callCount++;
+      if (callCount === 1) {
+        yield { type: 'text', delta: 'Response text.' } satisfies StreamEvent;
+        yield {
+          type: 'tool_call',
+          call: { id: 'call_1', name: 'tool1', arguments: '{}' },
+        } satisfies StreamEvent;
+        yield {
+          type: 'tool_call',
+          call: { id: 'call_2', name: 'tool2', arguments: '{}' },
+        } satisfies StreamEvent;
+        yield {
+          type: 'tool_call',
+          call: { id: 'call_3', name: 'tool3', arguments: '{}' },
+        } satisfies StreamEvent;
+        yield {
+          type: 'tool_call',
+          call: { id: 'call_4', name: 'tool4', arguments: '{}' },
+        } satisfies StreamEvent;
+        yield { type: 'finish', usage } satisfies StreamEvent;
+      } else {
+        yield { type: 'text', delta: 'Final answer.' } satisfies StreamEvent;
+        yield { type: 'finish', usage } satisfies StreamEvent;
+      }
+    });
+
+    const toolRegistry = {
+      tool1: {
+        definition: { name: 'tool1', description: '', parameters: {} },
+        handler: async () => 'result1',
+      },
+      tool2: {
+        definition: { name: 'tool2', description: '', parameters: {} },
+        handler: async () => 'result2',
+      },
+      tool3: {
+        definition: { name: 'tool3', description: '', parameters: {} },
+        handler: async () => 'result3',
+      },
+      tool4: {
+        definition: { name: 'tool4', description: '', parameters: {} },
+        handler: async () => 'result4',
+      },
+    };
+
+    runAgentLoop({
+      modelId: 'test-model',
+      modelName: 'Test Model',
+      apiKeyId: 'test-key',
+      messages,
+      toolRegistry,
+      agentName: 'Test Agent',
+      onTextChunk,
+      onComplete,
+      onError,
+    });
+
+    await expect.poll(() => onComplete).toHaveBeenCalled();
+
+    expect(onError).not.toHaveBeenCalled();
+
+    // Verify onComplete received agentLoopMessages with tool results
+    const agentLoopMessages = onComplete.mock.calls[0]?.[0].agentLoopMessages;
+
+    // Find the first assistant message with tool calls (iteration 1)
+    const firstAssistant = agentLoopMessages.find((msg: Message) => msg.role === 'assistant');
+    expect(firstAssistant).toBeDefined();
+    expect(firstAssistant.toolCalls).toHaveLength(4);
+
+    // Find tool result messages after the first assistant message
+    const firstAssistantIndex = agentLoopMessages.indexOf(firstAssistant);
+    const toolResultMessages = agentLoopMessages.slice(
+      firstAssistantIndex + 1,
+      firstAssistantIndex + 5,
+    );
+    expect(toolResultMessages).toHaveLength(4);
+
+    // First two tool calls should execute normally
+    expect(toolResultMessages[0].content).toBe('result1');
+    expect(toolResultMessages[1].content).toBe('result2');
+
+    // Last two should get budget error
+    expect(toolResultMessages[2].content).toContain('Tool call budget exceeded');
+    expect(toolResultMessages[3].content).toContain('Tool call budget exceeded');
+  });
+
   describe('Sentry instrumentation', () => {
     it('creates Sentry span for agent invocation', async () => {
       const messages: Message[] = [{ role: 'user', content: 'Test query' }];

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -60,6 +60,7 @@ export function runAgentLoop({
         async (agentSpan) => {
           for (let iteration = 0; iteration < MAX_AGENTIC_ITERATIONS; iteration++) {
             const pendingToolCalls: ToolCall[] = [];
+            const overBudgetToolCalls: ToolCall[] = [];
             let iterationText = '';
 
             // Add separator before starting a new iteration if the previous iteration produced text
@@ -88,28 +89,29 @@ export function runAgentLoop({
               if (event.type === 'text') {
                 iterationText += event.delta;
                 onTextChunk(event.delta);
-              } else if (
-                event.type === 'tool_call' &&
-                pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION
-              ) {
-                pendingToolCalls.push(event.call);
+              } else if (event.type === 'tool_call') {
+                if (pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION) {
+                  pendingToolCalls.push(event.call);
+                } else {
+                  overBudgetToolCalls.push(event.call);
+                }
               }
             }
 
             fullText += iterationText;
 
-            if (pendingToolCalls.length === 0) {
+            if (pendingToolCalls.length === 0 && overBudgetToolCalls.length === 0) {
               break;
             }
 
             loopMessages.push({
               role: 'assistant',
               content: iterationText,
-              toolCalls: pendingToolCalls,
+              toolCalls: [...pendingToolCalls, ...overBudgetToolCalls],
             });
 
-            const toolResults = await Promise.all(
-              pendingToolCalls.map((toolCall) =>
+            const toolResults = await Promise.all([
+              ...pendingToolCalls.map((toolCall) =>
                 Sentry.startSpan(
                   {
                     op: 'gen_ai.execute_tool',
@@ -146,7 +148,14 @@ export function runAgentLoop({
                   },
                 ),
               ),
-            );
+              ...overBudgetToolCalls.map(async (toolCall) => ({
+                toolCallId: toolCall.id,
+                result: `Error: Tool call budget exceeded.
+Maximum ${MAX_TOOL_CALLS_PER_ITERATION} tool calls per iteration.
+Do not mention this error to the user.
+Continue answering with the information you already have.`,
+              })),
+            ]);
 
             for (const { toolCallId, result } of toolResults) {
               loopMessages.push({ role: 'tool', content: result, toolCallId });

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -91,7 +91,10 @@ export function runAgentLoop({
                 onTextChunk(event.delta);
               } else if (event.type === 'tool_call') {
                 if (pendingToolCalls.length < MAX_TOOL_CALLS_PER_ITERATION) {
-                  pendingToolCalls.push(event.call);
+                  // On last iteration, tools are disabled but model might still emit tool calls
+                  if (!isLastIteration) {
+                    pendingToolCalls.push(event.call);
+                  }
                 } else {
                   overBudgetToolCalls.push(event.call);
                 }
@@ -150,10 +153,7 @@ export function runAgentLoop({
               ),
               ...overBudgetToolCalls.map(async (toolCall) => ({
                 toolCallId: toolCall.id,
-                result: `Error: Tool call budget exceeded.
-Maximum ${MAX_TOOL_CALLS_PER_ITERATION} tool calls per iteration.
-Do not mention this error to the user.
-Continue answering with the information you already have.`,
+                result: `Error: Tool call budget exceeded. Maximum ${MAX_TOOL_CALLS_PER_ITERATION} tool calls per iteration. Do not mention this error to the user. Continue answering with the information you already have.`,
               })),
             ]);
 


### PR DESCRIPTION
Track tool calls exceeding MAX_TOOL_CALLS_PER_ITERATION and return error responses instead of silently dropping them. Updated web_scraper tool to accept 1-5 URLs in a single call for parallel scraping. Added system prompt guideline to prevent models from outputting thinking process in visible output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)