### PR TITLE
TD-1379: enhance web_scraper tool to support multiple URLs

### DIFF
--- a/apps/chat-bot/src/app/api/chat/build-tools.test.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.test.ts
@@ -369,6 +369,103 @@ describe('buildTools', () => {
     ]);
   });
 
+  it('handles multiple URLs and returns multiple results', async () => {
+    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
+    mocks.webScraperMock
+      .mockResolvedValueOnce({
+        name: 'Erste Seite',
+        link: 'https://example.com/page1',
+        content: 'Inhalt der ersten Seite.',
+      })
+      .mockResolvedValueOnce({
+        name: 'Zweite Seite',
+        link: 'https://example.com/page2',
+        content: 'Inhalt der zweiten Seite.',
+      });
+
+    const { buildTools } = await import('./build-tools');
+    const { toolRegistry } = await buildTools({
+      user,
+      conversationId: 'conversation-1',
+      relatedFileEntities: [],
+    });
+
+    const result = await toolRegistry.web_scraper!.handler({
+      urls: ['https://example.com/page1', 'https://example.com/page2'],
+    });
+
+    expect(JSON.parse(result)).toEqual([
+      {
+        title: 'Erste Seite',
+        url: 'https://example.com/page1',
+        content: 'Inhalt der ersten Seite.',
+        error: null,
+      },
+      {
+        title: 'Zweite Seite',
+        url: 'https://example.com/page2',
+        content: 'Inhalt der zweiten Seite.',
+        error: null,
+      },
+    ]);
+  });
+
+  it('handles mixed success and failure with per-URL error results', async () => {
+    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
+    mocks.webScraperMock
+      .mockResolvedValueOnce({
+        name: 'Erfolgreiche Seite',
+        link: 'https://example.com/success',
+        content: 'Erfolgreicher Inhalt.',
+      })
+      .mockResolvedValueOnce({
+        link: 'https://example.com/failure',
+        error: true,
+      });
+
+    const { buildTools } = await import('./build-tools');
+    const { toolRegistry } = await buildTools({
+      user,
+      conversationId: 'conversation-1',
+      relatedFileEntities: [],
+    });
+
+    const result = await toolRegistry.web_scraper!.handler({
+      urls: ['https://example.com/success', 'https://example.com/failure'],
+    });
+
+    expect(JSON.parse(result)).toEqual([
+      {
+        title: 'Erfolgreiche Seite',
+        url: 'https://example.com/success',
+        content: 'Erfolgreicher Inhalt.',
+        error: null,
+      },
+      {
+        title: null,
+        url: 'https://example.com/failure',
+        content: null,
+        error: 'Failed to fetch the page.',
+      },
+    ]);
+  });
+
+  it('returns error when more than max URLs provided', async () => {
+    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
+    const { buildTools } = await import('./build-tools');
+    const { toolRegistry } = await buildTools({
+      user,
+      conversationId: 'conversation-1',
+      relatedFileEntities: [],
+    });
+
+    const result = await toolRegistry.web_scraper!.handler({
+      urls: Array(6).fill('https://example.com'),
+    });
+
+    expect(result).toBe('Error: Maximum 5 URLs allowed per call.');
+  });
+
   it('adds a web search tool and returns search results as JSON', async () => {
     mocks.isWebSearchEnabledMock.mockResolvedValue(true);
     mocks.searchWebMock.mockResolvedValue([

--- a/apps/chat-bot/src/app/api/chat/build-tools.test.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.test.ts
@@ -341,27 +341,32 @@ describe('buildTools', () => {
     expect(webScraperTool.definition).toMatchObject({
       name: 'web_scraper',
     });
-    expect(webScraperTool.definition.description).toContain('single webpage URL');
+    expect(webScraperTool.definition.description).toContain('one or more URLs');
     expect(webScraperTool.definition.parameters).toMatchObject({
-      required: ['url'],
+      required: ['urls'],
       properties: {
-        url: {
-          type: 'string',
+        urls: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
         },
       },
     });
 
     const result = await webScraperTool.handler({
-      url: 'https://example.com/article',
+      urls: ['https://example.com/article'],
     });
 
     expect(mocks.webScraperMock).toHaveBeenCalledWith('https://example.com/article');
-    expect(JSON.parse(result)).toEqual({
-      title: 'Beispielseite',
-      url: 'https://example.com/article',
-      content: 'Das ist der extrahierte Inhalt.',
-      error: null,
-    });
+    expect(JSON.parse(result)).toEqual([
+      {
+        title: 'Beispielseite',
+        url: 'https://example.com/article',
+        content: 'Das ist der extrahierte Inhalt.',
+        error: null,
+      },
+    ]);
   });
 
   it('adds a web search tool and returns search results as JSON', async () => {

--- a/apps/chat-bot/src/app/api/chat/build-tools.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.ts
@@ -52,6 +52,8 @@ type RetrieveEntireFileToolResponse = {
   error: string | null;
 };
 
+const MAX_WEB_SCRAPER_URLS = 5;
+
 function formatRetrievedChunksForTool(chunks: Awaited<ReturnType<typeof retrieveChunksByQuery>>) {
   const formattedChunks: SemanticFileSearchChunkResult[] = chunks.map((chunk) => ({
     fileName: chunk.fileName ?? null,
@@ -264,39 +266,70 @@ export async function buildTools({
     const webScraperToolDefinition: ToolDefinition = {
       name: 'web_scraper',
       description:
-        'Fetch and extract the main text from one specific URL. Use this tool when the user gives you a single webpage URL or when you can derive a concrete URL yourself, for example to scrape a documentation page or another known target. Use web_search instead when you need to discover relevant pages or compare multiple sources.' +
+        `Fetch and extract the main text from one or more URLs (max ${MAX_WEB_SCRAPER_URLS}). Use this tool when the user gives you webpage URLs or when you can derive concrete URLs yourself, for example to scrape documentation pages or other known targets. Use web_search instead when you need to discover relevant pages or compare multiple sources.` +
         (attachedSourceUrls.length > 0
           ? `\n\nThe following URLs were pinned for this conversation and are likely relevant — consider scraping them when appropriate:\n${attachedSourceUrls.map((link) => `- ${link}`).join('\n')}`
           : ''),
       parameters: {
         type: 'object',
         properties: {
-          url: {
-            type: 'string',
+          urls: {
+            type: 'array',
             description:
-              'The exact URL of the page to scrape. It must be a single http or https URL. Only domain hosts are allowed (no localhost, .local, or IP addresses).',
+              'Array of URLs to scrape. Each must be a valid http or https URL. Only domain hosts are allowed (no localhost, .local, or IP addresses).',
+            items: {
+              type: 'string',
+            },
+            minItems: 1,
+            maxItems: MAX_WEB_SCRAPER_URLS,
           },
         },
-        required: ['url'],
+        required: ['urls'],
         additionalProperties: false,
       },
     };
 
     addTool(webScraperToolDefinition, async (args) => {
-      const url = typeof args.url === 'string' ? args.url.trim() : '';
+      const urls = Array.isArray(args.urls) ? args.urls : [];
 
-      if (url.length === 0) {
-        return 'Error: Missing URL.';
+      if (urls.length === 0) {
+        return 'Error: Missing URLs.';
       }
 
-      const validationResult = validateWebScraperUrl(url);
-
-      if (validationResult.error) {
-        return validationResult.error;
+      if (urls.length > MAX_WEB_SCRAPER_URLS) {
+        return `Error: Maximum ${MAX_WEB_SCRAPER_URLS} URLs allowed per call.`;
       }
 
-      const result = await webScraper(validationResult.url);
-      return formatWebScrapedContentForTool(result);
+      const results = await Promise.all(
+        urls.map(async (url) => {
+          const urlString = typeof url === 'string' ? url.trim() : '';
+
+          if (urlString.length === 0) {
+            return JSON.stringify({
+              title: null,
+              url: null,
+              content: null,
+              error: 'Empty URL.',
+            });
+          }
+
+          const validationResult = validateWebScraperUrl(urlString);
+
+          if (validationResult.error) {
+            return JSON.stringify({
+              title: null,
+              url: urlString,
+              content: null,
+              error: validationResult.error,
+            });
+          }
+
+          const result = await webScraper(validationResult.url);
+          return formatWebScrapedContentForTool(result);
+        }),
+      );
+
+      return JSON.stringify(results.map((r) => JSON.parse(r)));
     });
   }
 


### PR DESCRIPTION
Enhanced web_scraper tool to accept multiple URLs (max 5) instead of a single URL. URLs are scraped in parallel with individual error handling per URL. Returns an array of results instead of a single result object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)