### PR TITLE
TD-1379: refactor tools into separate modules

### DIFF
--- a/apps/chat-bot/src/app/api/chat/build-tools.test.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.test.ts
@@ -1,39 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { FileModelAndContent } from '@shared/db/schema';
 import type { UserAndContext } from '@/auth/types';
-import {
-  RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
-  VECTOR_SEARCH_LIMIT,
-} from '@/configuration-text-inputs/const';
+import type { FileModelAndContent } from '@shared/db/schema';
 
 const mocks = vi.hoisted(() => ({
-  isWebSearchEnabledMock: vi.fn(),
-  searchWebMock: vi.fn(),
-  ingestWebContentMock: vi.fn(),
-  retrieveChunksByQueryMock: vi.fn(),
-  webScraperMock: vi.fn(),
-  dbGetExtractedFileContentMock: vi.fn(),
+  buildWebSearchToolMock: vi.fn(),
+  buildWebScraperToolMock: vi.fn(),
+  buildRetrieveEntireFileToolMock: vi.fn(),
+  buildRetrieveTextChunksToolMock: vi.fn(),
 }));
 
-vi.mock('./websearch', () => ({
-  isWebSearchEnabled: mocks.isWebSearchEnabledMock,
-  searchWeb: mocks.searchWebMock,
+vi.mock('./tools/web-search-tool', () => ({
+  buildWebSearchTool: mocks.buildWebSearchToolMock,
 }));
 
-vi.mock('../rag/ingestWebContent', () => ({
-  ingestWebContent: mocks.ingestWebContentMock,
+vi.mock('./tools/web-scraper-tool', () => ({
+  buildWebScraperTool: mocks.buildWebScraperToolMock,
 }));
 
-vi.mock('../rag/rag-service', () => ({
-  retrieveChunksByQuery: mocks.retrieveChunksByQueryMock,
+vi.mock('./tools/retrieve-entire-file-tool', () => ({
+  buildRetrieveEntireFileTool: mocks.buildRetrieveEntireFileToolMock,
 }));
 
-vi.mock('../web-scraper/web-scraper', () => ({
-  webScraper: mocks.webScraperMock,
-}));
-
-vi.mock('@shared/db/functions/files', () => ({
-  dbGetExtractedFileContent: mocks.dbGetExtractedFileContentMock,
+vi.mock('./tools/retrieve-text-chunks-tool', () => ({
+  buildRetrieveTextChunksTool: mocks.buildRetrieveTextChunksToolMock,
 }));
 
 const user = {
@@ -41,472 +30,107 @@ const user = {
   userRole: 'teacher',
   federalState: {
     id: 'federal-state-1',
-    supportContacts: null,
-    chatStorageTime: 120,
-    featureToggles: {
-      isStudentAccessEnabled: true,
-      isCharacterEnabled: true,
-      isSharedChatEnabled: true,
-      isCustomGptEnabled: true,
-      isShareTemplateWithSchoolEnabled: true,
-      isAgenticChatEnabled: true,
-      isImageGenerationEnabled: true,
-      isWebSearchEnabled: false,
-    },
   },
 } as UserAndContext;
 
 const relatedFileEntities = [
   {
     id: 'file-1',
-    name: 'Arbeitsblatt.pdf',
-    size: 120_000,
-  },
-  {
-    id: 'file-2',
-    name: 'Leitfaden.txt',
-    size: 8_000,
+    name: 'test.pdf',
+    size: 1000,
   },
 ] as FileModelAndContent[];
 
-const fileContentsById = new Map<string, string>([
-  ['file-1', 'Erster Abschnitt. Zweiter Abschnitt. Dritter Abschnitt.'],
-  ['file-2', 'Kurzer Leitfaden.'],
-]);
-
 beforeEach(() => {
   vi.clearAllMocks();
-  for (const file of relatedFileEntities) {
-    file.content = undefined;
-  }
-  mocks.isWebSearchEnabledMock.mockResolvedValue(false);
-  mocks.searchWebMock.mockResolvedValue([]);
-  mocks.dbGetExtractedFileContentMock.mockImplementation(async (fileId: string) => {
-    return fileContentsById.get(fileId) ?? '';
-  });
-  mocks.retrieveChunksByQueryMock.mockResolvedValue([
-    {
-      id: 'chunk-1',
-      content: 'Erster relevanter Abschnitt.',
-      fileId: 'file-1',
-      fileName: 'Arbeitsblatt.pdf',
-      orderIndex: 0,
-      sourceType: 'file',
-      sourceUrl: null,
+
+  // Default mock implementations - return tool-like objects
+  mocks.buildWebSearchToolMock.mockResolvedValue({
+    definition: {
+      name: 'web_search',
+      description: 'Search the web',
+      parameters: { type: 'object', properties: {} },
     },
-  ]);
-  mocks.ingestWebContentMock.mockResolvedValue({ processedUrls: [], errorUrls: [] });
-  mocks.webScraperMock.mockResolvedValue({
-    name: 'Beispielseite',
-    link: 'https://example.com/article',
-    content: 'Das ist der extrahierte Inhalt.',
+    handler: vi.fn(),
+  });
+
+  mocks.buildWebScraperToolMock.mockReturnValue({
+    definition: {
+      name: 'web_scraper',
+      description: 'Scrape web pages',
+      parameters: { type: 'object', properties: {} },
+    },
+    handler: vi.fn(),
+  });
+
+  mocks.buildRetrieveEntireFileToolMock.mockReturnValue({
+    definition: {
+      name: 'retrieve_entire_file',
+      description: 'Retrieve entire file',
+      parameters: { type: 'object', properties: {} },
+    },
+    handler: vi.fn(),
+  });
+
+  mocks.buildRetrieveTextChunksToolMock.mockReturnValue({
+    definition: {
+      name: 'retrieve_text_chunks',
+      description: 'Retrieve text chunks',
+      parameters: { type: 'object', properties: {} },
+    },
+    handler: vi.fn(),
   });
 });
 
 describe('buildTools', () => {
-  it('adds a whole-file retrieval tool that returns the selected file content', async () => {
+  it('builds toolRegistry with all enabled tools', async () => {
     const { buildTools } = await import('./build-tools');
 
     const { toolRegistry } = await buildTools({
       user,
-      conversationId: 'conversation-1',
+      conversationId: 'conv-1',
       relatedFileEntities,
     });
 
-    expect(Object.keys(toolRegistry)).toContain('retrieve_entire_file');
-    const retrieveEntireFileTool = toolRegistry.retrieve_entire_file!;
-
-    expect(retrieveEntireFileTool.definition).toMatchObject({
-      name: 'retrieve_entire_file',
-    });
-    expect(retrieveEntireFileTool.definition.description).toContain(
-      'Arbeitsblatt.pdf (120000 bytes)',
-    );
-    expect(retrieveEntireFileTool.definition.description).toContain('Leitfaden.txt (8000 bytes)');
-    expect(retrieveEntireFileTool.definition.parameters).toMatchObject({
-      required: ['fileName'],
-    });
-
-    const result = await retrieveEntireFileTool.handler({
-      fileName: 'Arbeitsblatt.pdf',
-    });
-
-    expect(mocks.dbGetExtractedFileContentMock).toHaveBeenCalledWith('file-1');
-    expect(JSON.parse(result)).toEqual({
-      fileName: 'Arbeitsblatt.pdf',
-      content: 'Erster Abschnitt. Zweiter Abschnitt. Dritter Abschnitt.',
-      truncated: false,
-      characterCount: expect.any(Number),
-      maxCharacters: RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
-      error: null,
-    });
+    expect(Object.keys(toolRegistry)).toEqual([
+      'web_search',
+      'web_scraper',
+      'retrieve_entire_file',
+      'retrieve_text_chunks',
+    ]);
   });
 
-  it('caps whole-file retrieval at the configured character limit', async () => {
-    const { buildTools } = await import('./build-tools');
+  it('skips tools that return null', async () => {
+    mocks.buildWebSearchToolMock.mockResolvedValue(null);
+    mocks.buildWebScraperToolMock.mockReturnValue(null);
 
-    const veryLongFile = {
-      id: 'file-3',
-      name: 'Grossdatei.txt',
-    } as FileModelAndContent;
-    fileContentsById.set('file-3', 'a'.repeat(100_001));
-
-    const { toolRegistry } = await buildTools({
-      user,
-      conversationId: 'conversation-1',
-      relatedFileEntities: [veryLongFile],
-    });
-
-    const result = await toolRegistry.retrieve_entire_file!.handler({
-      fileName: 'Grossdatei.txt',
-    });
-
-    const parsed = JSON.parse(result) as {
-      truncated: boolean;
-      maxCharacters: number;
-      error: string | null;
-      characterCount: number;
-      content: string | null;
-    };
-
-    expect(parsed.truncated).toBe(true);
-    expect(parsed.maxCharacters).toBe(RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT);
-    expect(parsed.characterCount).toBeGreaterThan(RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT);
-    expect(parsed.error).toContain('truncated');
-    expect(parsed.content).not.toBeNull();
-  });
-
-  it('adds a chunk retrieval tool that exposes file names and forwards the search query', async () => {
     const { buildTools } = await import('./build-tools');
 
     const { toolRegistry } = await buildTools({
       user,
-      conversationId: 'conversation-1',
+      conversationId: 'conv-1',
       relatedFileEntities,
-      attachedLinks: [],
     });
 
-    expect(Object.keys(toolRegistry)).toContain('retrieve_text_chunks');
-    const retrieveTextChunksTool = toolRegistry.retrieve_text_chunks!;
+    expect(Object.keys(toolRegistry)).toEqual(['retrieve_entire_file', 'retrieve_text_chunks']);
+  });
 
-    expect(retrieveTextChunksTool.definition).toMatchObject({
-      name: 'retrieve_text_chunks',
-    });
-    expect(retrieveTextChunksTool.definition.description).toContain(
-      'Arbeitsblatt.pdf (120000 bytes)',
-    );
-    expect(retrieveTextChunksTool.definition.description).toContain('Leitfaden.txt (8000 bytes)');
-    expect(retrieveTextChunksTool.definition.parameters).toMatchObject({
-      required: ['search', 'limit'],
-      properties: {
-        limit: {
-          maximum: VECTOR_SEARCH_LIMIT,
-        },
-      },
+  it('passes onWebSearchResults callback to web search tool', async () => {
+    const { buildTools } = await import('./build-tools');
+
+    const onWebSearchResults = vi.fn();
+
+    await buildTools({
+      user,
+      conversationId: 'conv-1',
+      relatedFileEntities,
+      onWebSearchResults,
     });
 
-    const result = await retrieveTextChunksTool.handler({
-      search: 'relevante Passage',
-      limit: VECTOR_SEARCH_LIMIT + 5,
-    });
-
-    expect(mocks.retrieveChunksByQueryMock).toHaveBeenCalledWith(
+    expect(mocks.buildWebSearchToolMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        searchQuery: 'relevante Passage',
-        federalStateId: 'federal-state-1',
-        relatedFileEntities,
-        limit: VECTOR_SEARCH_LIMIT,
+        onWebSearchResults,
       }),
     );
-    expect(JSON.parse(result)).toEqual({
-      chunks: [
-        {
-          fileName: 'Arbeitsblatt.pdf',
-          orderIndex: 0,
-          content: 'Erster relevanter Abschnitt.',
-        },
-      ],
-      error: null,
-    });
-  });
-
-  it('adds a chunk retrieval tool for linked pages and forwards source urls', async () => {
-    mocks.ingestWebContentMock.mockResolvedValueOnce({
-      processedUrls: ['https://example.com/shared-page'],
-      errorUrls: [],
-    });
-
-    const { buildTools } = await import('./build-tools');
-
-    const { toolRegistry } = await buildTools({
-      user,
-      conversationId: 'conversation-1',
-      relatedFileEntities: [],
-      sourceUrls: ['https://example.com/shared-page'],
-    });
-
-    expect(Object.keys(toolRegistry)).toContain('retrieve_text_chunks');
-    const retrieveTextChunksTool = toolRegistry.retrieve_text_chunks!;
-
-    expect(retrieveTextChunksTool.definition.description).toContain(
-      'https://example.com/shared-page',
-    );
-
-    await retrieveTextChunksTool.handler({
-      search: 'verlinkter Inhalt',
-    });
-
-    expect(mocks.retrieveChunksByQueryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        searchQuery: 'verlinkter Inhalt',
-        federalStateId: 'federal-state-1',
-        relatedFileEntities: [],
-        sourceUrls: ['https://example.com/shared-page'],
-      }),
-    );
-  });
-
-  it('ingests linked pages before retrieving chunks', async () => {
-    mocks.retrieveChunksByQueryMock.mockResolvedValueOnce([
-      {
-        id: 'chunk-2',
-        content: 'Neu abgerufener Seitenabschnitt.',
-        fileId: null,
-        fileName: null,
-        orderIndex: 0,
-        sourceType: 'webpage',
-        sourceUrl: 'https://example.com/shared-page',
-      },
-    ]);
-    mocks.ingestWebContentMock.mockResolvedValueOnce({
-      processedUrls: ['https://example.com/shared-page'],
-      errorUrls: [],
-    });
-
-    const { buildTools } = await import('./build-tools');
-
-    const { toolRegistry } = await buildTools({
-      user,
-      conversationId: 'conversation-1',
-      relatedFileEntities: [],
-      sourceUrls: ['https://example.com/shared-page'],
-    });
-
-    const result = await toolRegistry.retrieve_text_chunks!.handler({
-      search: 'verlinkter Inhalt',
-    });
-
-    expect(mocks.ingestWebContentMock).toHaveBeenCalledWith({
-      urls: ['https://example.com/shared-page'],
-      federalStateId: 'federal-state-1',
-    });
-    expect(mocks.retrieveChunksByQueryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        searchQuery: 'verlinkter Inhalt',
-        federalStateId: 'federal-state-1',
-        relatedFileEntities: [],
-        sourceUrls: ['https://example.com/shared-page'],
-      }),
-    );
-    expect(JSON.parse(result)).toEqual({
-      chunks: [
-        {
-          fileName: null,
-          orderIndex: 0,
-          content: 'Neu abgerufener Seitenabschnitt.',
-        },
-      ],
-      error: null,
-    });
-  });
-
-  it('adds a web scraper tool and returns scraped page content', async () => {
-    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
-    const { buildTools } = await import('./build-tools');
-
-    const { toolRegistry } = await buildTools({
-      user,
-      conversationId: 'conversation-1',
-      relatedFileEntities: [],
-      attachedLinks: [],
-    });
-
-    const webSearchTool = toolRegistry.web_search!;
-    const webScraperTool = toolRegistry.web_scraper!;
-
-    expect(Object.keys(toolRegistry).sort()).toEqual(['web_scraper', 'web_search']);
-    expect(webSearchTool.definition).toMatchObject({
-      name: 'web_search',
-    });
-    expect(webScraperTool.definition).toMatchObject({
-      name: 'web_scraper',
-    });
-    expect(webScraperTool.definition.description).toContain('one or more URLs');
-    expect(webScraperTool.definition.parameters).toMatchObject({
-      required: ['urls'],
-      properties: {
-        urls: {
-          type: 'array',
-          items: {
-            type: 'string',
-          },
-        },
-      },
-    });
-
-    const result = await webScraperTool.handler({
-      urls: ['https://example.com/article'],
-    });
-
-    expect(mocks.webScraperMock).toHaveBeenCalledWith('https://example.com/article');
-    expect(JSON.parse(result)).toEqual([
-      {
-        title: 'Beispielseite',
-        url: 'https://example.com/article',
-        content: 'Das ist der extrahierte Inhalt.',
-        error: null,
-      },
-    ]);
-  });
-
-  it('handles multiple URLs and returns multiple results', async () => {
-    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
-    mocks.webScraperMock
-      .mockResolvedValueOnce({
-        name: 'Erste Seite',
-        link: 'https://example.com/page1',
-        content: 'Inhalt der ersten Seite.',
-      })
-      .mockResolvedValueOnce({
-        name: 'Zweite Seite',
-        link: 'https://example.com/page2',
-        content: 'Inhalt der zweiten Seite.',
-      });
-
-    const { buildTools } = await import('./build-tools');
-    const { toolRegistry } = await buildTools({
-      user,
-      conversationId: 'conversation-1',
-      relatedFileEntities: [],
-    });
-
-    const result = await toolRegistry.web_scraper!.handler({
-      urls: ['https://example.com/page1', 'https://example.com/page2'],
-    });
-
-    expect(JSON.parse(result)).toEqual([
-      {
-        title: 'Erste Seite',
-        url: 'https://example.com/page1',
-        content: 'Inhalt der ersten Seite.',
-        error: null,
-      },
-      {
-        title: 'Zweite Seite',
-        url: 'https://example.com/page2',
-        content: 'Inhalt der zweiten Seite.',
-        error: null,
-      },
-    ]);
-  });
-
-  it('handles mixed success and failure with per-URL error results', async () => {
-    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
-    mocks.webScraperMock
-      .mockResolvedValueOnce({
-        name: 'Erfolgreiche Seite',
-        link: 'https://example.com/success',
-        content: 'Erfolgreicher Inhalt.',
-      })
-      .mockResolvedValueOnce({
-        link: 'https://example.com/failure',
-        error: true,
-      });
-
-    const { buildTools } = await import('./build-tools');
-    const { toolRegistry } = await buildTools({
-      user,
-      conversationId: 'conversation-1',
-      relatedFileEntities: [],
-    });
-
-    const result = await toolRegistry.web_scraper!.handler({
-      urls: ['https://example.com/success', 'https://example.com/failure'],
-    });
-
-    expect(JSON.parse(result)).toEqual([
-      {
-        title: 'Erfolgreiche Seite',
-        url: 'https://example.com/success',
-        content: 'Erfolgreicher Inhalt.',
-        error: null,
-      },
-      {
-        title: null,
-        url: 'https://example.com/failure',
-        content: null,
-        error: 'Failed to fetch the page.',
-      },
-    ]);
-  });
-
-  it('returns error when more than max URLs provided', async () => {
-    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
-    const { buildTools } = await import('./build-tools');
-    const { toolRegistry } = await buildTools({
-      user,
-      conversationId: 'conversation-1',
-      relatedFileEntities: [],
-    });
-
-    const result = await toolRegistry.web_scraper!.handler({
-      urls: Array(6).fill('https://example.com'),
-    });
-
-    expect(result).toBe('Error: Maximum 5 URLs allowed per call.');
-  });
-
-  it('adds a web search tool and returns search results as JSON', async () => {
-    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
-    mocks.searchWebMock.mockResolvedValue([
-      {
-        name: 'Beispielartikel',
-        url: 'https://example.com/search-result',
-        content: 'Kurzer Auszug aus dem Suchergebnis.',
-      },
-    ]);
-
-    const { buildTools } = await import('./build-tools');
-
-    const { toolRegistry } = await buildTools({
-      user,
-      conversationId: 'conversation-1',
-      relatedFileEntities: [],
-      attachedLinks: [],
-    });
-
-    expect(Object.keys(toolRegistry).sort()).toEqual(['web_scraper', 'web_search']);
-
-    const result = await toolRegistry.web_search!.handler({
-      query: 'aktuelle information',
-    });
-
-    expect(mocks.searchWebMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: 'aktuelle information',
-        conversationId: 'conversation-1',
-        userId: 'user-1',
-      }),
-    );
-    expect(JSON.parse(result)).toEqual({
-      results: [
-        {
-          title: 'Beispielartikel',
-          url: 'https://example.com/search-result',
-          content: 'Kurzer Auszug aus dem Suchergebnis.',
-        },
-      ],
-      error: null,
-    });
   });
 });

--- a/apps/chat-bot/src/app/api/chat/build-tools.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.ts
@@ -1,7 +1,6 @@
-import type { ToolDefinition, ToolRegistry } from '@ais-chat/ai-core';
+import type { ToolRegistry } from '@ais-chat/ai-core';
 import type { UserAndContext } from '@/auth/types';
-import type { WebSearchResult } from '@shared/db/schema';
-import type { FileModelAndContent } from '@shared/db/schema';
+import type { FileModelAndContent, WebSearchResult } from '@shared/db/schema';
 import { buildWebSearchTool } from './tools/web-search-tool';
 import { buildWebScraperTool } from './tools/web-scraper-tool';
 import { buildRetrieveEntireFileTool } from './tools/retrieve-entire-file-tool';
@@ -21,7 +20,6 @@ type BuildToolsParams = {
 
 type BuildToolsResult = {
   toolRegistry: ToolRegistry;
-  tools: ToolDefinition[];
   webSearchResults: WebSearchResult[];
 };
 
@@ -37,7 +35,6 @@ export async function buildTools({
   onWebSearchResults,
 }: BuildToolsParams): Promise<BuildToolsResult> {
   const toolRegistry: ToolRegistry = {};
-  const tools: ToolDefinition[] = [];
   const webSearchResults: WebSearchResult[] = [];
 
   const webSearchTool = await buildWebSearchTool({
@@ -52,7 +49,6 @@ export async function buildTools({
 
   if (webSearchTool) {
     toolRegistry[webSearchTool.definition.name] = webSearchTool;
-    tools.push(webSearchTool.definition);
   }
 
   const webScraperTool = buildWebScraperTool({
@@ -64,7 +60,6 @@ export async function buildTools({
 
   if (webScraperTool) {
     toolRegistry[webScraperTool.definition.name] = webScraperTool;
-    tools.push(webScraperTool.definition);
   }
 
   const retrieveEntireFileTool = buildRetrieveEntireFileTool({
@@ -73,7 +68,6 @@ export async function buildTools({
 
   if (retrieveEntireFileTool) {
     toolRegistry[retrieveEntireFileTool.definition.name] = retrieveEntireFileTool;
-    tools.push(retrieveEntireFileTool.definition);
   }
 
   const retrieveTextChunksTool = buildRetrieveTextChunksTool({
@@ -85,8 +79,7 @@ export async function buildTools({
 
   if (retrieveTextChunksTool) {
     toolRegistry[retrieveTextChunksTool.definition.name] = retrieveTextChunksTool;
-    tools.push(retrieveTextChunksTool.definition);
   }
 
-  return { toolRegistry, tools, webSearchResults };
+  return { toolRegistry, webSearchResults };
 }

--- a/apps/chat-bot/src/app/api/chat/build-tools.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.ts
@@ -20,7 +20,6 @@ type BuildToolsParams = {
 
 type BuildToolsResult = {
   toolRegistry: ToolRegistry;
-  webSearchResults: WebSearchResult[];
 };
 
 export async function buildTools({
@@ -35,7 +34,6 @@ export async function buildTools({
   onWebSearchResults,
 }: BuildToolsParams): Promise<BuildToolsResult> {
   const toolRegistry: ToolRegistry = {};
-  const webSearchResults: WebSearchResult[] = [];
 
   const webSearchTool = await buildWebSearchTool({
     user,
@@ -43,7 +41,6 @@ export async function buildTools({
     learningScenarioId,
     assistantId,
     conversationId,
-    webSearchResults,
     onWebSearchResults,
   });
 
@@ -81,5 +78,5 @@ export async function buildTools({
     toolRegistry[retrieveTextChunksTool.definition.name] = retrieveTextChunksTool;
   }
 
-  return { toolRegistry, webSearchResults };
+  return { toolRegistry };
 }

--- a/apps/chat-bot/src/app/api/chat/build-tools.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.ts
@@ -1,161 +1,11 @@
-import { type ToolDefinition, type ToolRegistry } from '@ais-chat/ai-core';
-import { UserAndContext } from '@/auth/types';
-import { isWebSearchEnabled, searchWeb } from './websearch';
-import { dbGetExtractedFileContent } from '@shared/db/functions/files';
+import type { ToolDefinition, ToolRegistry } from '@ais-chat/ai-core';
+import type { UserAndContext } from '@/auth/types';
 import type { WebSearchResult } from '@shared/db/schema';
 import type { FileModelAndContent } from '@shared/db/schema';
-import type { WebSource } from '@shared/db/types';
-import {
-  RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
-  VECTOR_SEARCH_LIMIT,
-} from '@/configuration-text-inputs/const';
-import { ingestWebContent } from '../rag/ingestWebContent';
-import { retrieveChunksByQuery } from '../rag/rag-service';
-import { webScraper } from '../web-scraper/web-scraper';
-import { isIP } from 'node:net';
-
-type WebScraperToolResult = {
-  title: string | null;
-  url: string | null;
-  content: string | null;
-  error: string | null;
-};
-
-type WebSearchToolResult = {
-  title: string | null;
-  url: string | null;
-  content: string | null;
-};
-
-type WebSearchToolResponse = {
-  results: WebSearchToolResult[];
-  error: string | null;
-};
-
-type SemanticFileSearchChunkResult = {
-  fileName: string | null;
-  orderIndex: number | null;
-  content: string | null;
-};
-
-type SemanticFileSearchToolResponse = {
-  chunks: SemanticFileSearchChunkResult[];
-  error: string | null;
-};
-
-type RetrieveEntireFileToolResponse = {
-  fileName: string | null;
-  content: string | null;
-  truncated: boolean;
-  characterCount: number;
-  maxCharacters: number;
-  error: string | null;
-};
-
-const MAX_WEB_SCRAPER_URLS = 5;
-
-function formatRetrievedChunksForTool(chunks: Awaited<ReturnType<typeof retrieveChunksByQuery>>) {
-  const formattedChunks: SemanticFileSearchChunkResult[] = chunks.map((chunk) => ({
-    fileName: chunk.fileName ?? null,
-    orderIndex: chunk.orderIndex ?? null,
-    content: chunk.content ?? null,
-  }));
-
-  const response: SemanticFileSearchToolResponse = {
-    chunks: formattedChunks,
-    error: null,
-  };
-
-  if (chunks.length === 0) {
-    response.error = 'No matching chunks found.';
-  }
-
-  return JSON.stringify(response);
-}
-
-function truncateToCharacterLimit(text: string, maxCharacters: number) {
-  if (text.length <= maxCharacters) {
-    return text;
-  }
-
-  return text.slice(0, maxCharacters);
-}
-
-function formatEntireFileForTool(file: FileModelAndContent) {
-  const content = file.content?.trim() ?? '';
-  const characterCount = content.length;
-  const truncatedContent = truncateToCharacterLimit(content, RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT);
-  const truncated = truncatedContent.length !== content.length;
-
-  const response: RetrieveEntireFileToolResponse = {
-    fileName: file.name ?? null,
-    content: content.length > 0 ? truncatedContent : null,
-    truncated,
-    characterCount,
-    maxCharacters: RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
-    error: null,
-  };
-
-  if (!content) {
-    response.error = 'No usable content found.';
-  } else if (truncated) {
-    response.error = 'File content was truncated to fit the character limit.';
-  }
-
-  return JSON.stringify(response);
-}
-
-function formatWebScrapedContentForTool(result: WebSource) {
-  const title = result.name?.trim() || null;
-  const content = result.content?.trim() || null;
-
-  const response: WebScraperToolResult = {
-    title,
-    url: result.link ?? null,
-    content: null,
-    error: null,
-  };
-
-  if (result.error) {
-    response.error = 'Failed to fetch the page.';
-    return JSON.stringify(response);
-  }
-
-  if (!content) {
-    response.error = 'No usable content found.';
-    return JSON.stringify(response);
-  }
-
-  response.content = content;
-  return JSON.stringify(response);
-}
-
-function validateWebScraperUrl(inputUrl: string): { url: string; error?: string } {
-  let parsedUrl: URL;
-
-  try {
-    parsedUrl = new URL(inputUrl);
-  } catch {
-    return { url: '', error: 'Error: Invalid URL.' };
-  }
-
-  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-    return { url: '', error: 'Error: Only http and https URLs are allowed.' };
-  }
-
-  const hostname = parsedUrl.hostname.toLowerCase();
-
-  if (
-    hostname === 'localhost' ||
-    hostname.endsWith('.localhost') ||
-    hostname.endsWith('.local') ||
-    isIP(hostname) !== 0
-  ) {
-    return { url: '', error: 'Error: Only domain hosts are allowed.' };
-  }
-
-  return { url: parsedUrl.toString() };
-}
+import { buildWebSearchTool } from './tools/web-search-tool';
+import { buildWebScraperTool } from './tools/web-scraper-tool';
+import { buildRetrieveEntireFileTool } from './tools/retrieve-entire-file-tool';
+import { buildRetrieveTextChunksTool } from './tools/retrieve-text-chunks-tool';
 
 type BuildToolsParams = {
   user: UserAndContext;
@@ -172,7 +22,6 @@ type BuildToolsParams = {
 type BuildToolsResult = {
   toolRegistry: ToolRegistry;
   tools: ToolDefinition[];
-  toolHandlers: Record<string, (args: Record<string, unknown>) => Promise<string>>;
   webSearchResults: WebSearchResult[];
 };
 
@@ -189,262 +38,55 @@ export async function buildTools({
 }: BuildToolsParams): Promise<BuildToolsResult> {
   const toolRegistry: ToolRegistry = {};
   const tools: ToolDefinition[] = [];
-  const toolHandlers: Record<string, (args: Record<string, unknown>) => Promise<string>> = {};
   const webSearchResults: WebSearchResult[] = [];
-  const attachedFileDescriptions = relatedFileEntities.map(
-    (file) => `${file.name} (${file.size} bytes)`,
-  );
-  const attachedSourceUrls = sourceUrls.length > 0 ? sourceUrls : attachedLinks;
 
-  function addTool(
-    definition: ToolDefinition,
-    handler: (args: Record<string, unknown>) => Promise<string>,
-  ) {
-    toolRegistry[definition.name] = {
-      definition,
-      handler,
-    };
-    tools.push(definition);
-    toolHandlers[definition.name] = handler;
-  }
-  const webSearchEnabled = await isWebSearchEnabled({
+  const webSearchTool = await buildWebSearchTool({
     user,
     characterId,
     learningScenarioId,
     assistantId,
+    conversationId,
+    webSearchResults,
+    onWebSearchResults,
   });
 
-  if (webSearchEnabled) {
-    const webSearchToolDefinition: ToolDefinition = {
-      name: 'web_search',
-      description:
-        'Search the web for current information. Call this tool immediately and without asking for permission whenever the user asks about recent events, news, current data (weather, prices, scores), or any facts that may have changed after your knowledge cutoff. After receiving the results, synthesize them into a direct answer — do not call the tool again with a different query.',
-      parameters: {
-        type: 'object',
-        properties: {
-          query: {
-            type: 'string',
-            description:
-              'A concise search query (max 10 words) that captures the key information need. Write it in the same language as the user.',
-          },
-        },
-        required: ['query'],
-        additionalProperties: false,
-      },
-    };
-
-    addTool(webSearchToolDefinition, async (args) => {
-      const query = typeof args.query === 'string' ? args.query : '';
-      const results = await searchWeb({
-        query,
-        conversationId,
-        userId: user.id,
-      });
-
-      const response: WebSearchToolResponse = {
-        results: results.map((result) => ({
-          title: result.name?.trim() ?? null,
-          url: result.url ?? null,
-          content: result.content?.trim() ?? null,
-        })),
-        error: null,
-      };
-
-      webSearchResults.push(...results);
-      onWebSearchResults?.(results);
-
-      if (results.length === 0) {
-        response.error = 'No results found.';
-        return JSON.stringify(response);
-      }
-
-      return JSON.stringify(response);
-    });
+  if (webSearchTool) {
+    toolRegistry[webSearchTool.definition.name] = webSearchTool;
+    tools.push(webSearchTool.definition);
   }
 
-  if (!characterId && !learningScenarioId) {
-    const webScraperToolDefinition: ToolDefinition = {
-      name: 'web_scraper',
-      description:
-        `Fetch and extract the main text from one or more URLs (max ${MAX_WEB_SCRAPER_URLS}). Use this tool when the user gives you webpage URLs or when you can derive concrete URLs yourself, for example to scrape documentation pages or other known targets. Use web_search instead when you need to discover relevant pages or compare multiple sources.` +
-        (attachedSourceUrls.length > 0
-          ? `\n\nThe following URLs were pinned for this conversation and are likely relevant — consider scraping them when appropriate:\n${attachedSourceUrls.map((link) => `- ${link}`).join('\n')}`
-          : ''),
-      parameters: {
-        type: 'object',
-        properties: {
-          urls: {
-            type: 'array',
-            description:
-              'Array of URLs to scrape. Each must be a valid http or https URL. Only domain hosts are allowed (no localhost, .local, or IP addresses).',
-            items: {
-              type: 'string',
-            },
-            minItems: 1,
-            maxItems: MAX_WEB_SCRAPER_URLS,
-          },
-        },
-        required: ['urls'],
-        additionalProperties: false,
-      },
-    };
+  const webScraperTool = buildWebScraperTool({
+    characterId,
+    learningScenarioId,
+    sourceUrls,
+    attachedLinks,
+  });
 
-    addTool(webScraperToolDefinition, async (args) => {
-      const urls = Array.isArray(args.urls) ? args.urls : [];
-
-      if (urls.length === 0) {
-        return 'Error: Missing URLs.';
-      }
-
-      if (urls.length > MAX_WEB_SCRAPER_URLS) {
-        return `Error: Maximum ${MAX_WEB_SCRAPER_URLS} URLs allowed per call.`;
-      }
-
-      const results = await Promise.all(
-        urls.map(async (url) => {
-          const urlString = typeof url === 'string' ? url.trim() : '';
-
-          if (urlString.length === 0) {
-            return JSON.stringify({
-              title: null,
-              url: null,
-              content: null,
-              error: 'Empty URL.',
-            });
-          }
-
-          const validationResult = validateWebScraperUrl(urlString);
-
-          if (validationResult.error) {
-            return JSON.stringify({
-              title: null,
-              url: urlString,
-              content: null,
-              error: validationResult.error,
-            });
-          }
-
-          const result = await webScraper(validationResult.url);
-          return formatWebScrapedContentForTool(result);
-        }),
-      );
-
-      return JSON.stringify(results.map((r) => JSON.parse(r)));
-    });
+  if (webScraperTool) {
+    toolRegistry[webScraperTool.definition.name] = webScraperTool;
+    tools.push(webScraperTool.definition);
   }
 
-  if (relatedFileEntities.length > 0) {
-    const retrieveEntireFileToolDefinition: ToolDefinition = {
-      name: 'retrieve_entire_file',
-      description: `Retrieve the full content of one attached file by name. Available files right now: ${attachedFileDescriptions.join(', ') || 'none'}. Use this tool when you need the full text of a specific attached file instead of only relevant excerpts. The returned content is capped at ${RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT} characters.`,
-      parameters: {
-        type: 'object',
-        properties: {
-          fileName: {
-            type: 'string',
-            description: 'The exact name of the attached file to retrieve.',
-          },
-        },
-        required: ['fileName'],
-        additionalProperties: false,
-      },
-    };
+  const retrieveEntireFileTool = buildRetrieveEntireFileTool({
+    relatedFileEntities,
+  });
 
-    toolRegistry.retrieve_entire_file = {
-      definition: retrieveEntireFileToolDefinition,
-      handler: async (args) => {
-        const fileName = typeof args.fileName === 'string' ? args.fileName.trim() : '';
-
-        if (fileName.length === 0) {
-          const response: RetrieveEntireFileToolResponse = {
-            fileName: null,
-            content: null,
-            truncated: false,
-            characterCount: 0,
-            maxCharacters: RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
-            error: 'Missing file name.',
-          };
-
-          return JSON.stringify(response);
-        }
-
-        const matchedFile = relatedFileEntities.find((file) => file.name === fileName);
-
-        if (matchedFile === undefined) {
-          const response: RetrieveEntireFileToolResponse = {
-            fileName,
-            content: null,
-            truncated: false,
-            characterCount: 0,
-            maxCharacters: RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
-            error: 'File not found.',
-          };
-
-          return JSON.stringify(response);
-        }
-
-        if (matchedFile.content === undefined) {
-          matchedFile.content = await dbGetExtractedFileContent(matchedFile.id);
-        }
-
-        return formatEntireFileForTool(matchedFile);
-      },
-    };
+  if (retrieveEntireFileTool) {
+    toolRegistry[retrieveEntireFileTool.definition.name] = retrieveEntireFileTool;
+    tools.push(retrieveEntireFileTool.definition);
   }
 
-  if (relatedFileEntities.length > 0 || attachedSourceUrls.length > 0) {
-    const retrieveTextChunksToolDefinition: ToolDefinition = {
-      name: 'retrieve_text_chunks',
-      description: `Retrieve relevant text chunks from the attached sources. Available files right now: ${attachedFileDescriptions.join(', ') || 'none'}. Available linked pages right now: ${attachedSourceUrls.join(', ') || 'none'}. Use this tool when you need exact passages from the files or linked pages or want to inspect a specific topic inside the available sources. You can request up to ${VECTOR_SEARCH_LIMIT} chunks per call. Call it with a short, specific search string in the same language as the user.`,
-      parameters: {
-        type: 'object',
-        properties: {
-          search: {
-            type: 'string',
-            description:
-              'A concise search string that captures the exact topic or passage you want to retrieve.',
-          },
-          limit: {
-            type: 'integer',
-            minimum: 1,
-            maximum: VECTOR_SEARCH_LIMIT,
-            description:
-              'Optional number of chunks to return. Values outside the allowed range are clamped.',
-          },
-        },
-        required: ['search', 'limit'],
-        additionalProperties: false,
-      },
-    };
+  const retrieveTextChunksTool = buildRetrieveTextChunksTool({
+    user,
+    relatedFileEntities,
+    sourceUrls,
+    attachedLinks,
+  });
 
-    addTool(retrieveTextChunksToolDefinition, async (args) => {
-      let processedSourceUrls = attachedSourceUrls;
-
-      if (attachedSourceUrls.length > 0) {
-        const { processedUrls } = await ingestWebContent({
-          urls: attachedSourceUrls,
-          federalStateId: user.federalState.id,
-        });
-
-        processedSourceUrls = processedUrls;
-      }
-      const search = typeof args.search === 'string' ? args.search : '';
-      const requestedLimit =
-        typeof args.limit === 'number' && Number.isFinite(args.limit)
-          ? Math.trunc(args.limit)
-          : VECTOR_SEARCH_LIMIT;
-      const limit = Math.min(Math.max(requestedLimit, 1), VECTOR_SEARCH_LIMIT);
-      const chunks = await retrieveChunksByQuery({
-        searchQuery: search,
-        federalStateId: user.federalState.id,
-        relatedFileEntities,
-        sourceUrls: processedSourceUrls,
-        limit,
-      });
-
-      return formatRetrievedChunksForTool(chunks);
-    });
+  if (retrieveTextChunksTool) {
+    toolRegistry[retrieveTextChunksTool.definition.name] = retrieveTextChunksTool;
+    tools.push(retrieveTextChunksTool.definition);
   }
 
-  return { toolRegistry, tools, toolHandlers, webSearchResults };
+  return { toolRegistry, tools, webSearchResults };
 }

--- a/apps/chat-bot/src/app/api/chat/chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.test.ts
@@ -30,9 +30,6 @@ const buildToolsOutput = {
       parameters: {},
     },
   ],
-  toolHandlers: {
-    web_search: vi.fn(),
-  },
   webSearchResults,
 };
 

--- a/apps/chat-bot/src/app/api/chat/chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.test.ts
@@ -361,12 +361,9 @@ describe('sendChatMessage', () => {
       expect(mocks.extractUrlsMock).toHaveBeenCalledTimes(1);
       expect(mocks.ingestWebContentMock).toHaveBeenCalledTimes(1);
       expect(mocks.constructChatSystemPromptMock).toHaveBeenCalledWith(
-        expect.objectContaining({ errorUrls: [] }),
-      );
-      expect(result.webSearchResults).toEqual(webSearchResults);
-      expect(mocks.constructChatSystemPromptMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          webSearchResults,
+          errorUrls: [],
+          webSearchResults: [],
           activeToolDefinitions: [buildToolsOutput.toolRegistry.web_search.definition],
         }),
       );

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -409,7 +409,6 @@ export async function sendChatMessage({
       },
     });
 
-    webSearchResults = builtTools.webSearchResults;
     toolRegistry = builtTools.toolRegistry;
     activeToolDefinitions = Object.values(toolRegistry).map((entry) => entry.definition);
   } else {

--- a/apps/chat-bot/src/app/api/chat/tools/retrieve-entire-file-tool.test.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/retrieve-entire-file-tool.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileModelAndContent } from '@shared/db/schema';
+import { RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT } from '@/configuration-text-inputs/const';
+
+const mocks = vi.hoisted(() => ({
+  dbGetExtractedFileContentMock: vi.fn(),
+}));
+
+vi.mock('@shared/db/functions/files', () => ({
+  dbGetExtractedFileContent: mocks.dbGetExtractedFileContentMock,
+}));
+
+const relatedFileEntities = [
+  {
+    id: 'file-1',
+    name: 'Arbeitsblatt.pdf',
+    size: 120_000,
+  },
+  {
+    id: 'file-2',
+    name: 'Leitfaden.txt',
+    size: 8_000,
+  },
+] as FileModelAndContent[];
+
+const fileContentsById = new Map<string, string>([
+  ['file-1', 'Erster Abschnitt. Zweiter Abschnitt. Dritter Abschnitt.'],
+  ['file-2', 'Kurzer Leitfaden.'],
+]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const file of relatedFileEntities) {
+    file.content = undefined;
+  }
+  mocks.dbGetExtractedFileContentMock.mockImplementation(async (fileId: string) => {
+    return fileContentsById.get(fileId) ?? '';
+  });
+});
+
+describe('buildRetrieveEntireFileTool', () => {
+  it('returns null when no files are attached', async () => {
+    const { buildRetrieveEntireFileTool } = await import('./retrieve-entire-file-tool');
+
+    const result = buildRetrieveEntireFileTool({
+      relatedFileEntities: [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('adds a whole-file retrieval tool that returns the selected file content', async () => {
+    const { buildRetrieveEntireFileTool } = await import('./retrieve-entire-file-tool');
+
+    const tool = buildRetrieveEntireFileTool({
+      relatedFileEntities,
+    });
+
+    expect(tool).not.toBeNull();
+    expect(tool!.definition).toMatchObject({
+      name: 'retrieve_entire_file',
+    });
+    expect(tool!.definition.description).toContain('Arbeitsblatt.pdf (120000 bytes)');
+    expect(tool!.definition.description).toContain('Leitfaden.txt (8000 bytes)');
+    expect(tool!.definition.parameters).toMatchObject({
+      required: ['fileName'],
+    });
+
+    const result = await tool!.handler({
+      fileName: 'Arbeitsblatt.pdf',
+    });
+
+    expect(mocks.dbGetExtractedFileContentMock).toHaveBeenCalledWith('file-1');
+    expect(JSON.parse(result)).toEqual({
+      fileName: 'Arbeitsblatt.pdf',
+      content: 'Erster Abschnitt. Zweiter Abschnitt. Dritter Abschnitt.',
+      truncated: false,
+      characterCount: expect.any(Number),
+      maxCharacters: RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
+      error: null,
+    });
+  });
+
+  it('caps whole-file retrieval at the configured character limit', async () => {
+    const { buildRetrieveEntireFileTool } = await import('./retrieve-entire-file-tool');
+
+    const veryLongFile = {
+      id: 'file-3',
+      name: 'Grossdatei.txt',
+    } as FileModelAndContent;
+    fileContentsById.set('file-3', 'a'.repeat(100_001));
+
+    const tool = buildRetrieveEntireFileTool({
+      relatedFileEntities: [veryLongFile],
+    });
+
+    const result = await tool!.handler({
+      fileName: 'Grossdatei.txt',
+    });
+
+    const parsed = JSON.parse(result) as {
+      truncated: boolean;
+      maxCharacters: number;
+      error: string | null;
+      characterCount: number;
+      content: string | null;
+    };
+
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.maxCharacters).toBe(RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT);
+    expect(parsed.characterCount).toBeGreaterThan(RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT);
+    expect(parsed.error).toContain('truncated');
+    expect(parsed.content).not.toBeNull();
+  });
+
+  it('returns error for missing file name', async () => {
+    const { buildRetrieveEntireFileTool } = await import('./retrieve-entire-file-tool');
+
+    const tool = buildRetrieveEntireFileTool({
+      relatedFileEntities,
+    });
+
+    const result = await tool!.handler({
+      fileName: '',
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toBe('Missing file name.');
+    expect(mocks.dbGetExtractedFileContentMock).not.toHaveBeenCalled();
+  });
+
+  it('returns error for file not found', async () => {
+    const { buildRetrieveEntireFileTool } = await import('./retrieve-entire-file-tool');
+
+    const tool = buildRetrieveEntireFileTool({
+      relatedFileEntities,
+    });
+
+    const result = await tool!.handler({
+      fileName: 'NonExistent.txt',
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toBe('File not found.');
+    expect(parsed.fileName).toBe('NonExistent.txt');
+    expect(mocks.dbGetExtractedFileContentMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/chat-bot/src/app/api/chat/tools/retrieve-entire-file-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/retrieve-entire-file-tool.ts
@@ -1,0 +1,115 @@
+import { RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT } from '@/configuration-text-inputs/const';
+import { dbGetExtractedFileContent } from '@shared/db/functions/files';
+import type { FileModelAndContent } from '@shared/db/schema';
+import type { BuildToolsContext, ToolDefinition, ToolRegistration } from './types';
+
+type RetrieveEntireFileToolResponse = {
+  fileName: string | null;
+  content: string | null;
+  truncated: boolean;
+  characterCount: number;
+  maxCharacters: number;
+  error: string | null;
+};
+
+function truncateToCharacterLimit(text: string, maxCharacters: number) {
+  if (text.length <= maxCharacters) {
+    return text;
+  }
+
+  return text.slice(0, maxCharacters);
+}
+
+function formatEntireFileForTool(file: FileModelAndContent) {
+  const content = file.content?.trim() ?? '';
+  const characterCount = content.length;
+  const truncatedContent = truncateToCharacterLimit(content, RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT);
+  const truncated = truncatedContent.length !== content.length;
+
+  const response: RetrieveEntireFileToolResponse = {
+    fileName: file.name ?? null,
+    content: content.length > 0 ? truncatedContent : null,
+    truncated,
+    characterCount,
+    maxCharacters: RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
+    error: null,
+  };
+
+  if (!content) {
+    response.error = 'No usable content found.';
+  } else if (truncated) {
+    response.error = 'File content was truncated to fit the character limit.';
+  }
+
+  return JSON.stringify(response);
+}
+
+type BuildRetrieveEntireFileToolParams = Pick<BuildToolsContext, 'relatedFileEntities'>;
+
+export function buildRetrieveEntireFileTool({
+  relatedFileEntities,
+}: BuildRetrieveEntireFileToolParams): ToolRegistration | null {
+  if (relatedFileEntities.length === 0) {
+    return null;
+  }
+
+  const attachedFileDescriptions = relatedFileEntities.map(
+    (file) => `${file.name} (${file.size} bytes)`,
+  );
+
+  const definition: ToolDefinition = {
+    name: 'retrieve_entire_file',
+    description: `Retrieve the full content of one attached file by name. Available files right now: ${attachedFileDescriptions.join(', ') || 'none'}. Use this tool when you need the full text of a specific attached file instead of only relevant excerpts. The returned content is capped at ${RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT} characters.`,
+    parameters: {
+      type: 'object',
+      properties: {
+        fileName: {
+          type: 'string',
+          description: 'The exact name of the attached file to retrieve.',
+        },
+      },
+      required: ['fileName'],
+      additionalProperties: false,
+    },
+  };
+
+  const handler = async (args: Record<string, unknown>) => {
+    const fileName = typeof args.fileName === 'string' ? args.fileName.trim() : '';
+
+    if (fileName.length === 0) {
+      const response: RetrieveEntireFileToolResponse = {
+        fileName: null,
+        content: null,
+        truncated: false,
+        characterCount: 0,
+        maxCharacters: RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
+        error: 'Missing file name.',
+      };
+
+      return JSON.stringify(response);
+    }
+
+    const matchedFile = relatedFileEntities.find((file) => file.name === fileName);
+
+    if (matchedFile === undefined) {
+      const response: RetrieveEntireFileToolResponse = {
+        fileName,
+        content: null,
+        truncated: false,
+        characterCount: 0,
+        maxCharacters: RETRIEVE_ENTIRE_FILE_CHARACTER_LIMIT,
+        error: 'File not found.',
+      };
+
+      return JSON.stringify(response);
+    }
+
+    if (matchedFile.content === undefined) {
+      matchedFile.content = await dbGetExtractedFileContent(matchedFile.id);
+    }
+
+    return formatEntireFileForTool(matchedFile);
+  };
+
+  return { definition, handler };
+}

--- a/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.test.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileModelAndContent } from '@shared/db/schema';
+import type { UserAndContext } from '@/auth/types';
+import { VECTOR_SEARCH_LIMIT } from '@/configuration-text-inputs/const';
+
+const mocks = vi.hoisted(() => ({
+  ingestWebContentMock: vi.fn(),
+  retrieveChunksByQueryMock: vi.fn(),
+}));
+
+vi.mock('../../rag/ingestWebContent', () => ({
+  ingestWebContent: mocks.ingestWebContentMock,
+}));
+
+vi.mock('../../rag/rag-service', () => ({
+  retrieveChunksByQuery: mocks.retrieveChunksByQueryMock,
+}));
+
+const user = {
+  id: 'user-1',
+  userRole: 'teacher',
+  federalState: {
+    id: 'federal-state-1',
+    supportContacts: null,
+    chatStorageTime: 120,
+    featureToggles: {
+      isStudentAccessEnabled: true,
+      isCharacterEnabled: true,
+      isSharedChatEnabled: true,
+      isCustomGptEnabled: true,
+      isShareTemplateWithSchoolEnabled: true,
+      isAgenticChatEnabled: true,
+      isImageGenerationEnabled: true,
+      isWebSearchEnabled: false,
+    },
+  },
+} as UserAndContext;
+
+const relatedFileEntities = [
+  {
+    id: 'file-1',
+    name: 'Arbeitsblatt.pdf',
+    size: 120_000,
+  },
+  {
+    id: 'file-2',
+    name: 'Leitfaden.txt',
+    size: 8_000,
+  },
+] as FileModelAndContent[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.retrieveChunksByQueryMock.mockResolvedValue([
+    {
+      id: 'chunk-1',
+      content: 'Erster relevanter Abschnitt.',
+      fileId: 'file-1',
+      fileName: 'Arbeitsblatt.pdf',
+      orderIndex: 0,
+      sourceType: 'file',
+      sourceUrl: null,
+    },
+  ]);
+  mocks.ingestWebContentMock.mockResolvedValue({ processedUrls: [], errorUrls: [] });
+});
+
+describe('buildRetrieveTextChunksTool', () => {
+  it('returns null when no files and no source URLs', async () => {
+    const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+    const result = buildRetrieveTextChunksTool({
+      user,
+      relatedFileEntities: [],
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('adds a chunk retrieval tool that exposes file names and forwards the search query', async () => {
+    const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+    const tool = buildRetrieveTextChunksTool({
+      user,
+      relatedFileEntities,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    expect(tool).not.toBeNull();
+    expect(tool!.definition).toMatchObject({
+      name: 'retrieve_text_chunks',
+    });
+    expect(tool!.definition.description).toContain('Arbeitsblatt.pdf (120000 bytes)');
+    expect(tool!.definition.description).toContain('Leitfaden.txt (8000 bytes)');
+    expect(tool!.definition.parameters).toMatchObject({
+      required: ['search', 'limit'],
+      properties: {
+        limit: {
+          maximum: VECTOR_SEARCH_LIMIT,
+        },
+      },
+    });
+
+    const result = await tool!.handler({
+      search: 'relevante Passage',
+      limit: VECTOR_SEARCH_LIMIT + 5,
+    });
+
+    expect(mocks.retrieveChunksByQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchQuery: 'relevante Passage',
+        federalStateId: 'federal-state-1',
+        relatedFileEntities,
+        limit: VECTOR_SEARCH_LIMIT,
+      }),
+    );
+    expect(JSON.parse(result)).toEqual({
+      chunks: [
+        {
+          fileName: 'Arbeitsblatt.pdf',
+          orderIndex: 0,
+          content: 'Erster relevanter Abschnitt.',
+        },
+      ],
+      error: null,
+    });
+  });
+
+  it('adds a chunk retrieval tool for linked pages and forwards source urls', async () => {
+    mocks.ingestWebContentMock.mockResolvedValueOnce({
+      processedUrls: ['https://example.com/shared-page'],
+      errorUrls: [],
+    });
+
+    const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+    const tool = buildRetrieveTextChunksTool({
+      user,
+      relatedFileEntities: [],
+      sourceUrls: ['https://example.com/shared-page'],
+      attachedLinks: [],
+    });
+
+    expect(tool).not.toBeNull();
+    expect(tool!.definition.description).toContain('https://example.com/shared-page');
+
+    await tool!.handler({
+      search: 'verlinkter Inhalt',
+    });
+
+    expect(mocks.retrieveChunksByQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchQuery: 'verlinkter Inhalt',
+        federalStateId: 'federal-state-1',
+        relatedFileEntities: [],
+        sourceUrls: ['https://example.com/shared-page'],
+      }),
+    );
+  });
+
+  it('ingests linked pages before retrieving chunks', async () => {
+    mocks.retrieveChunksByQueryMock.mockResolvedValueOnce([
+      {
+        id: 'chunk-2',
+        content: 'Neu abgerufener Seitenabschnitt.',
+        fileId: null,
+        fileName: null,
+        orderIndex: 0,
+        sourceType: 'webpage',
+        sourceUrl: 'https://example.com/shared-page',
+      },
+    ]);
+    mocks.ingestWebContentMock.mockResolvedValueOnce({
+      processedUrls: ['https://example.com/shared-page'],
+      errorUrls: [],
+    });
+
+    const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+    const tool = buildRetrieveTextChunksTool({
+      user,
+      relatedFileEntities: [],
+      sourceUrls: ['https://example.com/shared-page'],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      search: 'verlinkter Inhalt',
+    });
+
+    expect(mocks.ingestWebContentMock).toHaveBeenCalledWith({
+      urls: ['https://example.com/shared-page'],
+      federalStateId: 'federal-state-1',
+    });
+    expect(mocks.retrieveChunksByQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchQuery: 'verlinkter Inhalt',
+        federalStateId: 'federal-state-1',
+        relatedFileEntities: [],
+        sourceUrls: ['https://example.com/shared-page'],
+      }),
+    );
+    expect(JSON.parse(result)).toEqual({
+      chunks: [
+        {
+          fileName: null,
+          orderIndex: 0,
+          content: 'Neu abgerufener Seitenabschnitt.',
+        },
+      ],
+      error: null,
+    });
+  });
+
+  it('returns error when no chunks found', async () => {
+    mocks.retrieveChunksByQueryMock.mockResolvedValueOnce([]);
+
+    const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+    const tool = buildRetrieveTextChunksTool({
+      user,
+      relatedFileEntities,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      search: 'not found',
+      limit: 5,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.chunks).toEqual([]);
+    expect(parsed.error).toBe('No matching chunks found.');
+  });
+});

--- a/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.ts
@@ -1,0 +1,110 @@
+import { VECTOR_SEARCH_LIMIT } from '@/configuration-text-inputs/const';
+import { ingestWebContent } from '../../rag/ingestWebContent';
+import { retrieveChunksByQuery } from '../../rag/rag-service';
+import type { BuildToolsContext, ToolDefinition, ToolRegistration } from './types';
+
+type SemanticFileSearchChunkResult = {
+  fileName: string | null;
+  orderIndex: number | null;
+  content: string | null;
+};
+
+type SemanticFileSearchToolResponse = {
+  chunks: SemanticFileSearchChunkResult[];
+  error: string | null;
+};
+
+function formatRetrievedChunksForTool(chunks: Awaited<ReturnType<typeof retrieveChunksByQuery>>) {
+  const formattedChunks: SemanticFileSearchChunkResult[] = chunks.map((chunk) => ({
+    fileName: chunk.fileName ?? null,
+    orderIndex: chunk.orderIndex ?? null,
+    content: chunk.content ?? null,
+  }));
+
+  const response: SemanticFileSearchToolResponse = {
+    chunks: formattedChunks,
+    error: null,
+  };
+
+  if (chunks.length === 0) {
+    response.error = 'No matching chunks found.';
+  }
+
+  return JSON.stringify(response);
+}
+
+type BuildRetrieveTextChunksToolParams = Pick<
+  BuildToolsContext,
+  'user' | 'relatedFileEntities' | 'sourceUrls' | 'attachedLinks'
+>;
+
+export function buildRetrieveTextChunksTool({
+  user,
+  relatedFileEntities,
+  sourceUrls,
+  attachedLinks,
+}: BuildRetrieveTextChunksToolParams): ToolRegistration | null {
+  const attachedSourceUrls = sourceUrls.length > 0 ? sourceUrls : attachedLinks;
+
+  if (relatedFileEntities.length === 0 && attachedSourceUrls.length === 0) {
+    return null;
+  }
+
+  const attachedFileDescriptions = relatedFileEntities.map(
+    (file) => `${file.name} (${file.size} bytes)`,
+  );
+
+  const definition: ToolDefinition = {
+    name: 'retrieve_text_chunks',
+    description: `Retrieve relevant text chunks from the attached sources. Available files right now: ${attachedFileDescriptions.join(', ') || 'none'}. Available linked pages right now: ${attachedSourceUrls.join(', ') || 'none'}. Use this tool when you need exact passages from the files or linked pages or want to inspect a specific topic inside the available sources. You can request up to ${VECTOR_SEARCH_LIMIT} chunks per call. Call it with a short, specific search string in the same language as the user.`,
+    parameters: {
+      type: 'object',
+      properties: {
+        search: {
+          type: 'string',
+          description:
+            'A concise search string that captures the exact topic or passage you want to retrieve.',
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: VECTOR_SEARCH_LIMIT,
+          description:
+            'Optional number of chunks to return. Values outside the allowed range are clamped.',
+        },
+      },
+      required: ['search', 'limit'],
+      additionalProperties: false,
+    },
+  };
+
+  const handler = async (args: Record<string, unknown>) => {
+    let processedSourceUrls = attachedSourceUrls;
+
+    if (attachedSourceUrls.length > 0) {
+      const { processedUrls } = await ingestWebContent({
+        urls: attachedSourceUrls,
+        federalStateId: user.federalState.id,
+      });
+
+      processedSourceUrls = processedUrls;
+    }
+    const search = typeof args.search === 'string' ? args.search : '';
+    const requestedLimit =
+      typeof args.limit === 'number' && Number.isFinite(args.limit)
+        ? Math.trunc(args.limit)
+        : VECTOR_SEARCH_LIMIT;
+    const limit = Math.min(Math.max(requestedLimit, 1), VECTOR_SEARCH_LIMIT);
+    const chunks = await retrieveChunksByQuery({
+      searchQuery: search,
+      federalStateId: user.federalState.id,
+      relatedFileEntities,
+      sourceUrls: processedSourceUrls,
+      limit,
+    });
+
+    return formatRetrievedChunksForTool(chunks);
+  };
+
+  return { definition, handler };
+}

--- a/apps/chat-bot/src/app/api/chat/tools/types.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/types.ts
@@ -1,0 +1,23 @@
+import { type ToolDefinition, type ToolRegistry } from '@ais-chat/ai-core';
+import type { UserAndContext } from '@/auth/types';
+import type { FileModelAndContent } from '@shared/db/schema';
+import type { WebSearchResult } from '@shared/db/schema';
+
+export type { ToolDefinition, ToolRegistry };
+
+export type ToolRegistration = {
+  definition: ToolDefinition;
+  handler: (args: Record<string, unknown>) => Promise<string>;
+};
+
+export type BuildToolsContext = {
+  user: UserAndContext;
+  characterId?: string;
+  learningScenarioId?: string;
+  assistantId?: string;
+  conversationId: string;
+  relatedFileEntities: FileModelAndContent[];
+  sourceUrls: string[];
+  attachedLinks: string[];
+  onWebSearchResults?: (results: WebSearchResult[]) => void;
+};

--- a/apps/chat-bot/src/app/api/chat/tools/web-scraper-tool.test.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/web-scraper-tool.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  webScraperMock: vi.fn(),
+}));
+
+vi.mock('../../web-scraper/web-scraper', () => ({
+  webScraper: mocks.webScraperMock,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.webScraperMock.mockResolvedValue({
+    name: 'Beispielseite',
+    link: 'https://example.com/article',
+    content: 'Das ist der extrahierte Inhalt.',
+  });
+});
+
+describe('buildWebScraperTool', () => {
+  it('returns null when characterId is provided', async () => {
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const result = buildWebScraperTool({
+      characterId: 'character-1',
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when learningScenarioId is provided', async () => {
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const result = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: 'scenario-1',
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('adds a web scraper tool and returns scraped page content', async () => {
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    expect(tool).not.toBeNull();
+    expect(tool!.definition).toMatchObject({
+      name: 'web_scraper',
+    });
+    expect(tool!.definition.description).toContain('one or more URLs');
+    expect(tool!.definition.parameters).toMatchObject({
+      required: ['urls'],
+      properties: {
+        urls: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+    });
+
+    const result = await tool!.handler({
+      urls: ['https://example.com/article'],
+    });
+
+    expect(mocks.webScraperMock).toHaveBeenCalledWith('https://example.com/article');
+    expect(JSON.parse(result)).toEqual([
+      {
+        title: 'Beispielseite',
+        url: 'https://example.com/article',
+        content: 'Das ist der extrahierte Inhalt.',
+        error: null,
+      },
+    ]);
+  });
+
+  it('includes attached source URLs in the description', async () => {
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: ['https://example.com/doc1', 'https://example.com/doc2'],
+      attachedLinks: [],
+    });
+
+    expect(tool!.definition.description).toContain('https://example.com/doc1');
+    expect(tool!.definition.description).toContain('https://example.com/doc2');
+  });
+
+  it('validates URLs and rejects localhost', async () => {
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      urls: ['http://localhost:3000/test'],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed[0].error).toContain('Only domain hosts are allowed');
+    expect(mocks.webScraperMock).not.toHaveBeenCalled();
+  });
+
+  it('validates URLs and rejects IP addresses', async () => {
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      urls: ['http://192.168.1.1/test'],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed[0].error).toContain('Only domain hosts are allowed');
+    expect(mocks.webScraperMock).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple URLs in a single call', async () => {
+    mocks.webScraperMock
+      .mockResolvedValueOnce({
+        name: 'Page 1',
+        link: 'https://example.com/page1',
+        content: 'Content 1',
+      })
+      .mockResolvedValueOnce({
+        name: 'Page 2',
+        link: 'https://example.com/page2',
+        content: 'Content 2',
+      });
+
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      urls: ['https://example.com/page1', 'https://example.com/page2'],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].title).toBe('Page 1');
+    expect(parsed[1].title).toBe('Page 2');
+    expect(mocks.webScraperMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('enforces maximum URL limit', async () => {
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      urls: Array.from({ length: 10 }, (_, i) => `https://example.com/page${i}`),
+    });
+
+    expect(result).toContain('Maximum 5 URLs allowed');
+    expect(mocks.webScraperMock).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple URLs and returns multiple results', async () => {
+    mocks.webScraperMock
+      .mockResolvedValueOnce({
+        name: 'Erste Seite',
+        link: 'https://example.com/page1',
+        content: 'Inhalt der ersten Seite.',
+      })
+      .mockResolvedValueOnce({
+        name: 'Zweite Seite',
+        link: 'https://example.com/page2',
+        content: 'Inhalt der zweiten Seite.',
+      });
+
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      urls: ['https://example.com/page1', 'https://example.com/page2'],
+    });
+
+    expect(JSON.parse(result)).toEqual([
+      {
+        title: 'Erste Seite',
+        url: 'https://example.com/page1',
+        content: 'Inhalt der ersten Seite.',
+        error: null,
+      },
+      {
+        title: 'Zweite Seite',
+        url: 'https://example.com/page2',
+        content: 'Inhalt der zweiten Seite.',
+        error: null,
+      },
+    ]);
+  });
+
+  it('handles mixed success and failure with per-URL error results', async () => {
+    mocks.webScraperMock
+      .mockResolvedValueOnce({
+        name: 'Erfolgreiche Seite',
+        link: 'https://example.com/success',
+        content: 'Erfolgreicher Inhalt.',
+      })
+      .mockResolvedValueOnce({
+        link: 'https://example.com/failure',
+        error: true,
+      });
+
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      urls: ['https://example.com/success', 'https://example.com/failure'],
+    });
+
+    expect(JSON.parse(result)).toEqual([
+      {
+        title: 'Erfolgreiche Seite',
+        url: 'https://example.com/success',
+        content: 'Erfolgreicher Inhalt.',
+        error: null,
+      },
+      {
+        title: null,
+        url: 'https://example.com/failure',
+        content: null,
+        error: 'Failed to fetch the page.',
+      },
+    ]);
+  });
+
+  it('returns error when more than max URLs provided', async () => {
+    const { buildWebScraperTool } = await import('./web-scraper-tool');
+
+    const tool = buildWebScraperTool({
+      characterId: undefined,
+      learningScenarioId: undefined,
+      sourceUrls: [],
+      attachedLinks: [],
+    });
+
+    const result = await tool!.handler({
+      urls: Array(6).fill('https://example.com'),
+    });
+
+    expect(result).toBe('Error: Maximum 5 URLs allowed per call.');
+  });
+});

--- a/apps/chat-bot/src/app/api/chat/tools/web-scraper-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/web-scraper-tool.ts
@@ -1,0 +1,154 @@
+import { isIP } from 'node:net';
+import type { WebSource } from '@shared/db/types';
+import { webScraper } from '../../web-scraper/web-scraper';
+import type { BuildToolsContext, ToolDefinition, ToolRegistration } from './types';
+
+type WebScraperToolResult = {
+  title: string | null;
+  url: string | null;
+  content: string | null;
+  error: string | null;
+};
+
+const MAX_WEB_SCRAPER_URLS = 5;
+
+function formatWebScrapedContentForTool(result: WebSource) {
+  const title = result.name?.trim() || null;
+  const content = result.content?.trim() || null;
+
+  const response: WebScraperToolResult = {
+    title,
+    url: result.link ?? null,
+    content: null,
+    error: null,
+  };
+
+  if (result.error) {
+    response.error = 'Failed to fetch the page.';
+    return JSON.stringify(response);
+  }
+
+  if (!content) {
+    response.error = 'No usable content found.';
+    return JSON.stringify(response);
+  }
+
+  response.content = content;
+  return JSON.stringify(response);
+}
+
+function validateWebScraperUrl(inputUrl: string): { url: string; error?: string } {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(inputUrl);
+  } catch {
+    return { url: '', error: 'Error: Invalid URL.' };
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    return { url: '', error: 'Error: Only http and https URLs are allowed.' };
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    isIP(hostname) !== 0
+  ) {
+    return { url: '', error: 'Error: Only domain hosts are allowed.' };
+  }
+
+  return { url: parsedUrl.toString() };
+}
+
+type BuildWebScraperToolParams = Pick<
+  BuildToolsContext,
+  'characterId' | 'learningScenarioId' | 'sourceUrls' | 'attachedLinks'
+>;
+
+export function buildWebScraperTool({
+  characterId,
+  learningScenarioId,
+  sourceUrls,
+  attachedLinks,
+}: BuildWebScraperToolParams): ToolRegistration | null {
+  if (characterId || learningScenarioId) {
+    return null;
+  }
+
+  const attachedSourceUrls = sourceUrls.length > 0 ? sourceUrls : attachedLinks;
+
+  const definition: ToolDefinition = {
+    name: 'web_scraper',
+    description:
+      `Fetch and extract the main text from one or more URLs (max ${MAX_WEB_SCRAPER_URLS}). Use this tool when the user gives you webpage URLs or when you can derive concrete URLs yourself, for example to scrape documentation pages or other known targets. Use web_search instead when you need to discover relevant pages or compare multiple sources.` +
+      (attachedSourceUrls.length > 0
+        ? `\n\nThe following URLs were pinned for this conversation and are likely relevant — consider scraping them when appropriate:\n${attachedSourceUrls.map((link) => `- ${link}`).join('\n')}`
+        : ''),
+    parameters: {
+      type: 'object',
+      properties: {
+        urls: {
+          type: 'array',
+          description:
+            'Array of URLs to scrape. Each must be a valid http or https URL. Only domain hosts are allowed (no localhost, .local, or IP addresses).',
+          items: {
+            type: 'string',
+          },
+          minItems: 1,
+          maxItems: MAX_WEB_SCRAPER_URLS,
+        },
+      },
+      required: ['urls'],
+      additionalProperties: false,
+    },
+  };
+
+  const handler = async (args: Record<string, unknown>) => {
+    const urls = Array.isArray(args.urls) ? args.urls : [];
+
+    if (urls.length === 0) {
+      return 'Error: Missing URLs.';
+    }
+
+    if (urls.length > MAX_WEB_SCRAPER_URLS) {
+      return `Error: Maximum ${MAX_WEB_SCRAPER_URLS} URLs allowed per call.`;
+    }
+
+    const results = await Promise.all(
+      urls.map(async (url) => {
+        const urlString = typeof url === 'string' ? url.trim() : '';
+
+        if (urlString.length === 0) {
+          return JSON.stringify({
+            title: null,
+            url: null,
+            content: null,
+            error: 'Empty URL.',
+          });
+        }
+
+        const validationResult = validateWebScraperUrl(urlString);
+
+        if (validationResult.error) {
+          return JSON.stringify({
+            title: null,
+            url: urlString,
+            content: null,
+            error: validationResult.error,
+          });
+        }
+
+        const result = await webScraper(validationResult.url);
+        return formatWebScrapedContentForTool(result);
+      }),
+    );
+
+    return JSON.stringify(results.map((r) => JSON.parse(r)));
+  };
+
+  return { definition, handler };
+}

--- a/apps/chat-bot/src/app/api/chat/tools/web-search-tool.test.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/web-search-tool.test.ts
@@ -45,7 +45,6 @@ describe('buildWebSearchTool', () => {
     const result = await buildWebSearchTool({
       user,
       conversationId: 'conversation-1',
-      webSearchResults: [],
     });
 
     expect(result).toBeNull();
@@ -63,11 +62,9 @@ describe('buildWebSearchTool', () => {
 
     const { buildWebSearchTool } = await import('./web-search-tool');
 
-    const webSearchResults: any[] = [];
     const tool = await buildWebSearchTool({
       user,
       conversationId: 'conversation-1',
-      webSearchResults,
     });
 
     expect(tool).not.toBeNull();
@@ -99,7 +96,6 @@ describe('buildWebSearchTool', () => {
       ],
       error: null,
     });
-    expect(webSearchResults).toHaveLength(1);
   });
 
   it('calls onWebSearchResults callback when provided', async () => {
@@ -118,7 +114,6 @@ describe('buildWebSearchTool', () => {
     const tool = await buildWebSearchTool({
       user,
       conversationId: 'conversation-1',
-      webSearchResults: [],
       onWebSearchResults,
     });
 

--- a/apps/chat-bot/src/app/api/chat/tools/web-search-tool.test.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/web-search-tool.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UserAndContext } from '@/auth/types';
+
+const mocks = vi.hoisted(() => ({
+  isWebSearchEnabledMock: vi.fn(),
+  searchWebMock: vi.fn(),
+}));
+
+vi.mock('../websearch', () => ({
+  isWebSearchEnabled: mocks.isWebSearchEnabledMock,
+  searchWeb: mocks.searchWebMock,
+}));
+
+const user = {
+  id: 'user-1',
+  userRole: 'teacher',
+  federalState: {
+    id: 'federal-state-1',
+    supportContacts: null,
+    chatStorageTime: 120,
+    featureToggles: {
+      isStudentAccessEnabled: true,
+      isCharacterEnabled: true,
+      isSharedChatEnabled: true,
+      isCustomGptEnabled: true,
+      isShareTemplateWithSchoolEnabled: true,
+      isAgenticChatEnabled: true,
+      isImageGenerationEnabled: true,
+      isWebSearchEnabled: false,
+    },
+  },
+} as UserAndContext;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isWebSearchEnabledMock.mockResolvedValue(false);
+  mocks.searchWebMock.mockResolvedValue([]);
+});
+
+describe('buildWebSearchTool', () => {
+  it('returns null when web search is disabled', async () => {
+    mocks.isWebSearchEnabledMock.mockResolvedValue(false);
+    const { buildWebSearchTool } = await import('./web-search-tool');
+
+    const result = await buildWebSearchTool({
+      user,
+      conversationId: 'conversation-1',
+      webSearchResults: [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('adds a web search tool and returns search results as JSON', async () => {
+    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
+    mocks.searchWebMock.mockResolvedValue([
+      {
+        name: 'Beispielartikel',
+        url: 'https://example.com/search-result',
+        content: 'Kurzer Auszug aus dem Suchergebnis.',
+      },
+    ]);
+
+    const { buildWebSearchTool } = await import('./web-search-tool');
+
+    const webSearchResults: any[] = [];
+    const tool = await buildWebSearchTool({
+      user,
+      conversationId: 'conversation-1',
+      webSearchResults,
+    });
+
+    expect(tool).not.toBeNull();
+    expect(tool!.definition).toMatchObject({
+      name: 'web_search',
+    });
+    expect(tool!.definition.parameters).toMatchObject({
+      required: ['query'],
+    });
+
+    const result = await tool!.handler({
+      query: 'aktuelle information',
+    });
+
+    expect(mocks.searchWebMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'aktuelle information',
+        conversationId: 'conversation-1',
+        userId: 'user-1',
+      }),
+    );
+    expect(JSON.parse(result)).toEqual({
+      results: [
+        {
+          title: 'Beispielartikel',
+          url: 'https://example.com/search-result',
+          content: 'Kurzer Auszug aus dem Suchergebnis.',
+        },
+      ],
+      error: null,
+    });
+    expect(webSearchResults).toHaveLength(1);
+  });
+
+  it('calls onWebSearchResults callback when provided', async () => {
+    mocks.isWebSearchEnabledMock.mockResolvedValue(true);
+    mocks.searchWebMock.mockResolvedValue([
+      {
+        name: 'Test',
+        url: 'https://example.com',
+        content: 'Content',
+      },
+    ]);
+
+    const { buildWebSearchTool } = await import('./web-search-tool');
+
+    const onWebSearchResults = vi.fn();
+    const tool = await buildWebSearchTool({
+      user,
+      conversationId: 'conversation-1',
+      webSearchResults: [],
+      onWebSearchResults,
+    });
+
+    await tool!.handler({ query: 'test' });
+
+    expect(onWebSearchResults).toHaveBeenCalledWith([
+      {
+        name: 'Test',
+        url: 'https://example.com',
+        content: 'Content',
+      },
+    ]);
+  });
+});

--- a/apps/chat-bot/src/app/api/chat/tools/web-search-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/web-search-tool.ts
@@ -17,7 +17,6 @@ type BuildWebSearchToolParams = Pick<
   BuildToolsContext,
   'user' | 'characterId' | 'learningScenarioId' | 'assistantId' | 'conversationId'
 > & {
-  webSearchResults: WebSearchResult[];
   onWebSearchResults?: (results: WebSearchResult[]) => void;
 };
 
@@ -27,7 +26,6 @@ export async function buildWebSearchTool({
   learningScenarioId,
   assistantId,
   conversationId,
-  webSearchResults,
   onWebSearchResults,
 }: BuildWebSearchToolParams): Promise<ToolRegistration | null> {
   const webSearchEnabled = await isWebSearchEnabled({
@@ -76,7 +74,6 @@ export async function buildWebSearchTool({
       error: null,
     };
 
-    webSearchResults.push(...results);
     onWebSearchResults?.(results);
 
     if (results.length === 0) {

--- a/apps/chat-bot/src/app/api/chat/tools/web-search-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/web-search-tool.ts
@@ -1,0 +1,91 @@
+import type { WebSearchResult } from '@shared/db/schema';
+import { isWebSearchEnabled, searchWeb } from '../websearch';
+import type { BuildToolsContext, ToolDefinition, ToolRegistration } from './types';
+
+type WebSearchToolResult = {
+  title: string | null;
+  url: string | null;
+  content: string | null;
+};
+
+type WebSearchToolResponse = {
+  results: WebSearchToolResult[];
+  error: string | null;
+};
+
+type BuildWebSearchToolParams = Pick<
+  BuildToolsContext,
+  'user' | 'characterId' | 'learningScenarioId' | 'assistantId' | 'conversationId'
+> & {
+  webSearchResults: WebSearchResult[];
+  onWebSearchResults?: (results: WebSearchResult[]) => void;
+};
+
+export async function buildWebSearchTool({
+  user,
+  characterId,
+  learningScenarioId,
+  assistantId,
+  conversationId,
+  webSearchResults,
+  onWebSearchResults,
+}: BuildWebSearchToolParams): Promise<ToolRegistration | null> {
+  const webSearchEnabled = await isWebSearchEnabled({
+    user,
+    characterId,
+    learningScenarioId,
+    assistantId,
+  });
+
+  if (!webSearchEnabled) {
+    return null;
+  }
+
+  const definition: ToolDefinition = {
+    name: 'web_search',
+    description:
+      'Search the web for current information. Call this tool immediately and without asking for permission whenever the user asks about recent events, news, current data (weather, prices, scores), or any facts that may have changed after your knowledge cutoff. After receiving the results, synthesize them into a direct answer — do not call the tool again with a different query.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'A concise search query (max 10 words) that captures the key information need. Write it in the same language as the user.',
+        },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+  };
+
+  const handler = async (args: Record<string, unknown>) => {
+    const query = typeof args.query === 'string' ? args.query : '';
+    const results = await searchWeb({
+      query,
+      conversationId,
+      userId: user.id,
+    });
+
+    const response: WebSearchToolResponse = {
+      results: results.map((result) => ({
+        title: result.name?.trim() ?? null,
+        url: result.url ?? null,
+        content: result.content?.trim() ?? null,
+      })),
+      error: null,
+    };
+
+    webSearchResults.push(...results);
+    onWebSearchResults?.(results);
+
+    if (results.length === 0) {
+      response.error = 'No results found.';
+      return JSON.stringify(response);
+    }
+
+    return JSON.stringify(response);
+  };
+
+  return { definition, handler };
+}


### PR DESCRIPTION
Refactors the build-tools.ts file by extracting individual tools into separate modules under `src/app/api/chat/tools/`:

- `web-scraper-tool.ts` - web scraper tool with multi-URL support
- `web-search-tool.ts` - web search tool
- `retrieve-entire-file-tool.ts` - full file retrieval tool
- `retrieve-text-chunks-tool.ts` - semantic chunk search tool
- `types.ts` - shared types and constants

Each tool module includes its own tests. This improves maintainability and makes the codebase easier to navigate.

Duplicates part of #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)