### PR TITLE
TD-268: use URL API for constructing service endpoints

### DIFF
--- a/apps/chat-bot/.env.example
+++ b/apps/chat-bot/.env.example
@@ -52,8 +52,11 @@ LOADTEST_PASSWORD=test
 LOADTEST_USERNAME=test
 
 # Crawl4AI configuration
-CRAWL4AI_URL=http://localhost:11235
+CRAWL4AI_URL=http://localhost:11235/
 CRAWL4AI_API_TOKEN=ais-chat-crawl4ai-token
+
+# Xberg file extraction configuration
+XBERG_URL=http://localhost:8000/
 
 # Google Vertex AI (Image Generation): path to the service account json file
 GOOGLE_APPLICATION_CREDENTIALS=

--- a/apps/chat-bot/src/app/api/file-extraction/file-extraction-xberg.ts
+++ b/apps/chat-bot/src/app/api/file-extraction/file-extraction-xberg.ts
@@ -22,7 +22,7 @@ export async function fileExtractionXberg({
     formData.append('files', new Blob([buffer as BlobPart]), filename);
     formData.append('output_format', 'markdown');
 
-    const response = await fetch(`${env.xbergUrl}/extract`, {
+    const response = await fetch(new URL('/extract', env.xbergUrl), {
       method: 'POST',
       body: formData,
       signal: AbortSignal.timeout(timeout),

--- a/apps/chat-bot/src/app/api/web-scraper/web-scraper-crawl4ai.ts
+++ b/apps/chat-bot/src/app/api/web-scraper/web-scraper-crawl4ai.ts
@@ -40,7 +40,7 @@ export async function webScraperCrawl4AI(url: string): Promise<WebSource> {
 
   try {
     const timeout = 30_000; // 30 seconds timeout for crawl4ai
-    const response = await fetch(`${env.crawl4AIUrl}/crawl`, {
+    const response = await fetch(new URL('/crawl', env.crawl4AIUrl), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Replace string concatenation with `new URL('/path', baseUrl)` for xberg and crawl4ai service endpoints
- Add `XBERG_URL` to `.env.example`
- Use trailing slashes for base URLs in example env

🤖 Generated with [Claude Code](https://claude.com/claude-code)