### PR TITLE
TD-1400: remove support for document type odp

### DIFF
--- a/apps/chat-bot/src/const.ts
+++ b/apps/chat-bot/src/const.ts
@@ -4,7 +4,6 @@ export const SUPPORTED_DOCUMENTS_EXTENSIONS = [
   'md',
   'txt',
   'pptx',
-  'odp',
   'csv',
   'xlsx',
   'ods',


### PR DESCRIPTION
Removes `odp` from the supported document extensions since xberg does not support parsing this format.

The extension was only referenced through the shared `SUPPORTED_DOCUMENTS_EXTENSIONS` constant, so removing it there propagates to file upload validation, drag-and-drop, and the AI system prompt automatically.