### PR TITLE
fix: isolate grace window e2e tests with beforeEach per test

### DIFF
--- a/apps/chat-bot/e2e/tests/character/create-character-chat.test.ts
+++ b/apps/chat-bot/e2e/tests/character/create-character-chat.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { AUTH_FILES, MOCK_LLM_COMMANDS } from '../../utils/const';
 import { regenerateMessage, sendMessage } from '../../utils/chat';
 import {
@@ -7,18 +7,10 @@ import {
   deleteCharacter,
   deleteCharacterFromDetailPage,
 } from '../../utils/character';
-import { waitForAutosave, waitForToast, waitForToastDisappear } from '../../utils/utils';
+import { stopShare, waitForAutosave, waitForToast, waitForToastDisappear } from '../../utils/utils';
 import { nanoid } from 'nanoid';
 
 test.use({ storageState: AUTH_FILES.teacher });
-
-async function confirmStopSharing(page: Page) {
-  await page.getByTestId('stop-share-button').click();
-  const stopShareDialog = page.getByTestId('stop-share-dialog');
-  await expect(stopShareDialog).toBeVisible();
-  await page.getByTestId('stop-share-confirm-button').click();
-  await expect(stopShareDialog).not.toBeVisible();
-}
 
 test.describe('create, share, chat, delete', () => {
   const characterName = 'John Cena ' + nanoid(8);
@@ -133,7 +125,7 @@ test.describe('create, share, chat, delete', () => {
     // stop share
     await page.goto(editorUrl);
     await page.waitForURL('/characters/editor/**');
-    await confirmStopSharing(page);
+    await stopShare(page);
     await expect(page.getByTestId('start-share-button')).toBeVisible();
 
     // verify maximum token points is preselected after stopping share

--- a/apps/chat-bot/e2e/tests/character/share-with-learners-grace-window.test.ts
+++ b/apps/chat-bot/e2e/tests/character/share-with-learners-grace-window.test.ts
@@ -4,65 +4,65 @@ import { configureCharacter, createCharacter } from '../../utils/character';
 import { waitForAutosave } from '../../utils/utils';
 import { nanoid } from 'nanoid';
 
-const characterName = 'Grace Window Character Test - ' + nanoid(8);
-
 test.describe('share character with grace window', () => {
+  test.use({ storageState: AUTH_FILES.teacher });
+
   let characterId: string;
 
-  test.beforeAll(async ({ browser }) => {
-    // Create character as teacher
-    const page = await browser.newPage({ storageState: AUTH_FILES.teacher });
+  test.beforeEach(async ({ page }) => {
     await createCharacter(page);
-    await configureCharacter(page, { name: characterName });
+    await configureCharacter(page, { name: 'Grace Window Character Test - ' + nanoid(8) });
     await waitForAutosave(page);
 
-    // Extract character ID from URL
     const url = page.url();
     const match = url.match(/characters\/editor\/([^/?]+)/);
     characterId = match ? match[1]! : '';
-
-    await page.close();
   });
 
-  test.describe('teacher perspective', () => {
-    test.use({ storageState: AUTH_FILES.teacher });
+  test('can extend a share session that has not yet expired', async ({ page }) => {
+    await page.goto(`/characters/editor/${characterId}`);
+    await page.waitForURL(`**/characters/editor/${characterId}**`);
 
-    test('can extend a share session that has not yet expired', async ({ page }) => {
-      await page.goto(`/characters/editor/${characterId}`);
-      await page.waitForURL(`**/characters/editor/${characterId}**`);
+    // Select usage time before starting share
+    await page.getByTestId('usage-time-select').click();
+    await page.getByTestId('usage-time-option-30').click();
 
-      // Select usage time before starting share
-      await page.getByTestId('usage-time-select').click();
-      await page.getByTestId('usage-time-option-30').click();
+    await page.getByTestId('start-share-button').click();
 
-      await page.getByTestId('start-share-button').click();
+    await page.waitForURL('**/characters/editor/**/share');
 
-      await page.waitForURL('**/characters/editor/**/share');
+    // Navigate back to editor to verify share is active
+    await page.goto(`/characters/editor/${characterId}`);
 
-      // Navigate back to editor to verify share is active
-      await page.goto(`/characters/editor/${characterId}`);
+    await expect(page.getByTestId('add-additional-time-button')).toBeVisible();
+    await expect(page.getByTestId('stop-share-button')).toBeVisible();
+  });
 
-      await expect(page.getByTestId('add-additional-time-button')).toBeVisible();
-      await expect(page.getByTestId('stop-share-button')).toBeVisible();
-    });
+  test('can manually stop a share session', async ({ page }) => {
+    await page.goto(`/characters/editor/${characterId}`);
+    await page.waitForURL(`**/characters/editor/${characterId}**`);
 
-    test('can manually stop a share session', async ({ page }) => {
-      await page.goto(`/characters/editor/${characterId}`);
-      await page.waitForURL(`**/characters/editor/${characterId}**`);
+    // Start sharing with 30 minutes
+    await page.getByTestId('usage-time-select').click();
+    await page.getByTestId('usage-time-option-30').click();
+    await page.getByTestId('start-share-button').click();
 
-      const stopShareButton = page.getByTestId('stop-share-button');
+    await page.waitForURL('**/characters/editor/**/share');
 
-      if (await stopShareButton.isVisible()) {
-        await stopShareButton.click();
+    // Navigate back to editor
+    await page.goto(`/characters/editor/${characterId}`);
+    await page.waitForURL(`**/characters/editor/${characterId}**`);
 
-        const stopShareDialog = page.getByTestId('stop-share-dialog');
-        await expect(stopShareDialog).toBeVisible();
+    const stopShareButton = page.getByTestId('stop-share-button');
+    await expect(stopShareButton).toBeVisible();
+    await stopShareButton.click();
 
-        await page.getByTestId('stop-share-confirm-button').click();
-        await expect(stopShareDialog).not.toBeVisible();
+    const stopShareDialog = page.getByTestId('stop-share-dialog');
+    await expect(stopShareDialog).toBeVisible();
 
-        await expect(page.getByTestId('start-share-button')).toBeVisible();
-      }
-    });
+    await page.getByTestId('stop-share-confirm-button').click();
+    await expect(stopShareDialog).not.toBeVisible();
+
+    await expect(page.getByTestId('start-share-button')).toBeVisible();
   });
 });

--- a/apps/chat-bot/e2e/tests/character/share-with-learners-grace-window.test.ts
+++ b/apps/chat-bot/e2e/tests/character/share-with-learners-grace-window.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
 import { configureCharacter, createCharacter } from '../../utils/character';
-import { waitForAutosave } from '../../utils/utils';
+import { startShare, stopShare, waitForAutosave } from '../../utils/utils';
 import { nanoid } from 'nanoid';
 
 test.describe('share character with grace window', () => {
@@ -22,18 +22,7 @@ test.describe('share character with grace window', () => {
 
   test('can extend a share session that has not yet expired', async ({ page }) => {
     await page.goto(`/characters/editor/${characterId}`);
-    await page.waitForURL(`**/characters/editor/${characterId}**`);
-
-    // Select usage time before starting share
-    await page.getByTestId('usage-time-select').click();
-    await page.getByTestId('usage-time-option-30').click();
-
-    await page.getByTestId('start-share-button').click();
-
-    await page.waitForURL('**/characters/editor/**/share');
-
-    // Navigate back to editor to verify share is active
-    await page.goto(`/characters/editor/${characterId}`);
+    await startShare(page, { id: characterId });
 
     await expect(page.getByTestId('add-additional-time-button')).toBeVisible();
     await expect(page.getByTestId('stop-share-button')).toBeVisible();
@@ -41,28 +30,8 @@ test.describe('share character with grace window', () => {
 
   test('can manually stop a share session', async ({ page }) => {
     await page.goto(`/characters/editor/${characterId}`);
-    await page.waitForURL(`**/characters/editor/${characterId}**`);
-
-    // Start sharing with 30 minutes
-    await page.getByTestId('usage-time-select').click();
-    await page.getByTestId('usage-time-option-30').click();
-    await page.getByTestId('start-share-button').click();
-
-    await page.waitForURL('**/characters/editor/**/share');
-
-    // Navigate back to editor
-    await page.goto(`/characters/editor/${characterId}`);
-    await page.waitForURL(`**/characters/editor/${characterId}**`);
-
-    const stopShareButton = page.getByTestId('stop-share-button');
-    await expect(stopShareButton).toBeVisible();
-    await stopShareButton.click();
-
-    const stopShareDialog = page.getByTestId('stop-share-dialog');
-    await expect(stopShareDialog).toBeVisible();
-
-    await page.getByTestId('stop-share-confirm-button').click();
-    await expect(stopShareDialog).not.toBeVisible();
+    await startShare(page, { id: characterId });
+    await stopShare(page);
 
     await expect(page.getByTestId('start-share-button')).toBeVisible();
   });

--- a/apps/chat-bot/e2e/tests/character/share-with-learners-grace-window.test.ts
+++ b/apps/chat-bot/e2e/tests/character/share-with-learners-grace-window.test.ts
@@ -16,7 +16,8 @@ test.describe('share character with grace window', () => {
 
     const url = page.url();
     const match = url.match(/characters\/editor\/([^/?]+)/);
-    characterId = match ? match[1]! : '';
+    expect(match, `Expected character editor URL, got: ${url}`).not.toBeNull();
+    characterId = match![1]!;
   });
 
   test('can extend a share session that has not yet expired', async ({ page }) => {

--- a/apps/chat-bot/e2e/tests/learning-scenarios/share-with-learners-grace-window.test.ts
+++ b/apps/chat-bot/e2e/tests/learning-scenarios/share-with-learners-grace-window.test.ts
@@ -16,7 +16,8 @@ test.describe('share learning scenario with 2-hour grace window', () => {
 
     const url = page.url();
     const match = url.match(/learning-scenarios\/editor\/([^/?]+)/);
-    learningScenarioId = match ? match[1]! : '';
+    expect(match, `Expected learning scenario editor URL, got: ${url}`).not.toBeNull();
+    learningScenarioId = match![1]!;
   });
 
   test('can extend a share session that has not yet expired', async ({ page }) => {

--- a/apps/chat-bot/e2e/tests/learning-scenarios/share-with-learners-grace-window.test.ts
+++ b/apps/chat-bot/e2e/tests/learning-scenarios/share-with-learners-grace-window.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { AUTH_FILES } from '../../utils/const';
 import { configureLearningScenario, createLearningScenario } from '../../utils/learning-scenario';
-import { waitForAutosave } from '../../utils/utils';
+import { startShare, stopShare, waitForAutosave } from '../../utils/utils';
 import { nanoid } from 'nanoid';
 
 test.describe('share learning scenario with 2-hour grace window', () => {
@@ -21,28 +21,9 @@ test.describe('share learning scenario with 2-hour grace window', () => {
   });
 
   test('can extend a share session that has not yet expired', async ({ page }) => {
-    // Navigate to learning scenario editor
     await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
-    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}**`);
+    await startShare(page, { id: learningScenarioId });
 
-    // Start sharing with 30 minutes
-    const startShareButton = page.getByTestId('start-share-button');
-    await expect(startShareButton).toBeVisible();
-
-    // Select 30 minutes usage time
-    await page.getByTestId('usage-time-select').click();
-    await page.getByTestId('usage-time-option-30').click();
-
-    // Click start share
-    await startShareButton.click();
-
-    // Wait for share to be started
-    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}/share`);
-
-    // Navigate back to editor to verify share is active
-    await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
-
-    // Verify extend button and stop button are visible with stable selectors
     await expect(page.getByTestId('add-additional-time-button')).toBeVisible();
     await expect(page.getByTestId('stop-share-button')).toBeVisible();
 
@@ -51,36 +32,11 @@ test.describe('share learning scenario with 2-hour grace window', () => {
   });
 
   test('can manually stop a share session', async ({ page }) => {
-    // Navigate to learning scenario editor
     await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
-    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}**`);
+    await startShare(page, { id: learningScenarioId });
+    await stopShare(page);
 
-    // Start sharing with 30 minutes
-    await page.getByTestId('usage-time-select').click();
-    await page.getByTestId('usage-time-option-30').click();
-    await page.getByTestId('start-share-button').click();
-
-    // Wait for share to be started
-    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}/share`);
-
-    // Navigate back to editor
-    await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
-    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}**`);
-
-    // Click stop share
-    const stopButton = page.getByTestId('stop-share-button');
-    await expect(stopButton).toBeVisible();
-    await stopButton.click();
-
-    // Confirm the action in the stop share dialog
-    await expect(page.getByTestId('stop-share-dialog')).toBeVisible();
-    await page.getByTestId('stop-share-confirm-button').click();
-    await expect(page.getByTestId('stop-share-dialog')).not.toBeVisible();
-
-    // Wait for page refresh
     await page.waitForLoadState('networkidle');
-
-    // Verify start button is now visible (share is stopped)
     await expect(page.getByTestId('start-share-button')).toBeVisible();
   });
 });

--- a/apps/chat-bot/e2e/tests/learning-scenarios/share-with-learners-grace-window.test.ts
+++ b/apps/chat-bot/e2e/tests/learning-scenarios/share-with-learners-grace-window.test.ts
@@ -4,82 +4,82 @@ import { configureLearningScenario, createLearningScenario } from '../../utils/l
 import { waitForAutosave } from '../../utils/utils';
 import { nanoid } from 'nanoid';
 
-const learningScenarioName = 'Grace Window Test - ' + nanoid(8);
-
 test.describe('share learning scenario with 2-hour grace window', () => {
+  test.use({ storageState: AUTH_FILES.teacher });
+
   let learningScenarioId: string;
 
-  test.beforeAll(async ({ browser }) => {
-    // Create learning scenario as teacher
-    const page = await browser.newPage({ storageState: AUTH_FILES.teacher });
+  test.beforeEach(async ({ page }) => {
     await createLearningScenario(page);
-    await configureLearningScenario(page, { name: learningScenarioName });
+    await configureLearningScenario(page, { name: 'Grace Window Test - ' + nanoid(8) });
     await waitForAutosave(page);
 
-    // Extract learning scenario ID from URL
     const url = page.url();
     const match = url.match(/learning-scenarios\/editor\/([^/?]+)/);
     learningScenarioId = match ? match[1]! : '';
-
-    await page.close();
   });
 
-  test.describe('teacher perspective', () => {
-    test.use({ storageState: AUTH_FILES.teacher });
+  test('can extend a share session that has not yet expired', async ({ page }) => {
+    // Navigate to learning scenario editor
+    await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
+    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}**`);
 
-    test('can extend a share session that has not yet expired', async ({ page }) => {
-      // Navigate to learning scenario editor
-      await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
-      await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}**`);
+    // Start sharing with 30 minutes
+    const startShareButton = page.getByTestId('start-share-button');
+    await expect(startShareButton).toBeVisible();
 
-      // Start sharing with 30 minutes
-      const startShareButton = page.getByTestId('start-share-button');
-      await expect(startShareButton).toBeVisible();
+    // Select 30 minutes usage time
+    await page.getByTestId('usage-time-select').click();
+    await page.getByTestId('usage-time-option-30').click();
 
-      // Select 30 minutes usage time
-      await page.getByTestId('usage-time-select').click();
-      await page.getByTestId('usage-time-option-30').click();
+    // Click start share
+    await startShareButton.click();
 
-      // Click start share
-      await startShareButton.click();
+    // Wait for share to be started
+    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}/share`);
 
-      // Wait for share to be started
-      await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}/share`);
+    // Navigate back to editor to verify share is active
+    await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
 
-      // Navigate back to editor to verify share is active
-      await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
+    // Verify extend button and stop button are visible with stable selectors
+    await expect(page.getByTestId('add-additional-time-button')).toBeVisible();
+    await expect(page.getByTestId('stop-share-button')).toBeVisible();
 
-      // Verify extend button and stop button are visible with stable selectors
-      await expect(page.getByTestId('add-additional-time-button')).toBeVisible();
-      await expect(page.getByTestId('stop-share-button')).toBeVisible();
+    // Running shares should allow opening the share page
+    await expect(page.getByTestId('open-share-page-button')).toBeEnabled();
+  });
 
-      // Running shares should allow opening the share page
-      await expect(page.getByTestId('open-share-page-button')).toBeEnabled();
-    });
+  test('can manually stop a share session', async ({ page }) => {
+    // Navigate to learning scenario editor
+    await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
+    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}**`);
 
-    test('can manually stop a share session', async ({ page }) => {
-      // Navigate to learning scenario editor
-      await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
-      await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}**`);
+    // Start sharing with 30 minutes
+    await page.getByTestId('usage-time-select').click();
+    await page.getByTestId('usage-time-option-30').click();
+    await page.getByTestId('start-share-button').click();
 
-      // Check if share is active by looking for stop button
-      const stopButton = page.getByTestId('stop-share-button');
+    // Wait for share to be started
+    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}/share`);
 
-      await expect(stopButton).toBeVisible();
-      // Click stop share
-      await stopButton.click();
+    // Navigate back to editor
+    await page.goto(`/learning-scenarios/editor/${learningScenarioId}`);
+    await page.waitForURL(`**/learning-scenarios/editor/${learningScenarioId}**`);
 
-      // Confirm the action in the stop share dialog
-      await expect(page.getByTestId('stop-share-dialog')).toBeVisible();
-      await page.getByTestId('stop-share-confirm-button').click();
-      await expect(page.getByTestId('stop-share-dialog')).not.toBeVisible();
+    // Click stop share
+    const stopButton = page.getByTestId('stop-share-button');
+    await expect(stopButton).toBeVisible();
+    await stopButton.click();
 
-      // Wait for page refresh
-      await page.waitForLoadState('networkidle');
+    // Confirm the action in the stop share dialog
+    await expect(page.getByTestId('stop-share-dialog')).toBeVisible();
+    await page.getByTestId('stop-share-confirm-button').click();
+    await expect(page.getByTestId('stop-share-dialog')).not.toBeVisible();
 
-      // Verify start button is now visible (share is stopped)
-      const startShareButton = page.getByTestId('start-share-button');
-      await expect(startShareButton).toBeVisible();
-    });
+    // Wait for page refresh
+    await page.waitForLoadState('networkidle');
+
+    // Verify start button is now visible (share is stopped)
+    await expect(page.getByTestId('start-share-button')).toBeVisible();
   });
 });

--- a/apps/chat-bot/e2e/utils/utils.ts
+++ b/apps/chat-bot/e2e/utils/utils.ts
@@ -1,5 +1,31 @@
 import { expect, Page } from '@playwright/test';
 
+export async function startShare(page: Page, { id }: { id: string }) {
+  await page.waitForURL(`**/editor/${id}**`);
+
+  await page.getByTestId('usage-time-select').click();
+  await page.getByTestId('usage-time-option-30').click();
+  await page.getByTestId('start-share-button').click();
+
+  await page.waitForURL(`**/editor/${id}/share`);
+
+  // Navigate back to editor so the caller can interact with the active share UI
+  await page.goBack();
+  await page.waitForURL(`**/editor/${id}**`);
+}
+
+export async function stopShare(page: Page) {
+  const stopButton = page.getByTestId('stop-share-button');
+  await expect(stopButton).toBeVisible();
+  await page.waitForLoadState('networkidle');
+  await stopButton.click();
+
+  const stopShareDialog = page.getByTestId('stop-share-dialog');
+  await expect(stopShareDialog).toBeVisible();
+  await page.getByTestId('stop-share-confirm-button').click();
+  await expect(stopShareDialog).not.toBeVisible();
+}
+
 export async function waitForToast(page: Page, msg?: string) {
   await page.getByLabel('Notifications (F8)').locator('li', { hasText: msg }).waitFor();
 }


### PR DESCRIPTION
The grace window e2e tests for characters and learning scenarios were sharing a single entity across tests via `beforeAll`. This caused the 'can manually stop a share session' test to fail on CI retry, because only the failing test is retried — not its predecessor that created the active share session.

Each test now creates its own entity in `beforeEach` using the test's own `page` fixture, making them fully independent. The nested `test.describe('teacher perspective')` wrapper was also removed since it's no longer needed.