### PR TITLE
fix: file upload limit error after deleting a file in file-upload-table

### DIFF
--- a/apps/chat-bot/src/components/custom-chat/files-and-links/file-drop-area.tsx
+++ b/apps/chat-bot/src/components/custom-chat/files-and-links/file-drop-area.tsx
@@ -35,43 +35,39 @@ export function FileDrop({
     return files.some((f) => validateFileExtension(f.name));
   }
 
-  const handleFiles = useCallback(
-    async (selectedFiles: FileList | undefined | null) => {
-      if (selectedFiles === null || selectedFiles === undefined) return;
-      const files = Array.from(selectedFiles);
+  async function handleFiles(selectedFiles: FileList | undefined | null) {
+    if (selectedFiles === null || selectedFiles === undefined) return;
+    const files = Array.from(selectedFiles);
 
-      const totalFileCount = countOfFiles ? countOfFiles + files.length : files.length;
+    const totalFileCount = countOfFiles ? countOfFiles + files.length : files.length;
 
-      if (totalFileCount > NUMBER_OF_FILES_LIMIT_FOR_SHARED_CHAT) {
-        toast.error(
-          t('toasts.file-limit-exceeded', {
-            max_files: NUMBER_OF_FILES_LIMIT_FOR_SHARED_CHAT,
-          }),
-        );
-        return;
-      }
-
-      await Promise.all(
-        files.map((f) =>
-          handleSingleFile({
-            file: f,
-            toast,
-            session,
-            setFiles,
-            onFileUploaded,
-            translations: t,
-            showUploadConfirmation,
-          }),
-        ),
+    if (totalFileCount > NUMBER_OF_FILES_LIMIT_FOR_SHARED_CHAT) {
+      toast.error(
+        t('toasts.file-limit-exceeded', {
+          max_files: NUMBER_OF_FILES_LIMIT_FOR_SHARED_CHAT,
+        }),
       );
+      return;
+    }
 
-      if (fileInputRef.current !== null) {
-        fileInputRef.current.value = '';
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [toast, session, setFiles, onFileUploaded, t, showUploadConfirmation],
-  );
+    await Promise.all(
+      files.map((f) =>
+        handleSingleFile({
+          file: f,
+          toast,
+          session,
+          setFiles,
+          onFileUploaded,
+          translations: t,
+          showUploadConfirmation,
+        }),
+      ),
+    );
+
+    if (fileInputRef.current !== null) {
+      fileInputRef.current.value = '';
+    }
+  }
 
   const handleDragEnter = useCallback((e: React.DragEvent<HTMLDivElement>): void => {
     e.preventDefault();
@@ -96,25 +92,22 @@ export function FileDrop({
     [isDragging],
   );
 
-  const handleDrop = useCallback(
-    (e: React.DragEvent<HTMLDivElement>): void => {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsDragging(false);
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
 
-      const { files } = e.dataTransfer;
-      if (!validateFileExtensions(files)) {
-        toast.error(
-          t('toasts.invalid-file-format', {
-            supported_formats: SUPPORTED_DOCUMENTS_EXTENSIONS.join(', '),
-          }),
-        );
-        return;
-      }
-      handleFiles(files);
-    },
-    [handleFiles, t, toast],
-  );
+    const { files } = e.dataTransfer;
+    if (!validateFileExtensions(files)) {
+      toast.error(
+        t('toasts.invalid-file-format', {
+          supported_formats: SUPPORTED_DOCUMENTS_EXTENSIONS.join(', '),
+        }),
+      );
+      return;
+    }
+    void handleFiles(files);
+  }
 
   const handleButtonClick = (): void => {
     if (fileInputRef.current) {


### PR DESCRIPTION
When 5 files were uploaded in an entity and one gets deleted, trying to upload a new file would incorrectly show the max-files error. After a page reload it worked fine.

The bug was a stale closure in `FileDrop`: `handleFiles` was wrapped in `useCallback` but `countOfFiles` was missing from the dependency array (suppressed with an eslint-disable comment). This caused the callback to always see the initial `countOfFiles` value, so the limit check used stale data.

Fix: convert `handleFiles` and `handleDrop` to plain functions so they always read the current `countOfFiles` from the closure, and remove the manual memoization that conflicted with the React Compiler.