### PR TITLE
TD-1413: skip embedding when all file+URL chunks fit within search limit

### DIFF
--- a/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.test.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.test.ts
@@ -6,6 +6,7 @@ import { VECTOR_SEARCH_LIMIT } from '@/configuration-text-inputs/const';
 const mocks = vi.hoisted(() => ({
   ingestWebContentMock: vi.fn(),
   retrieveChunksByQueryMock: vi.fn(),
+  dbGetAllChunksMock: vi.fn(),
 }));
 
 vi.mock('../../rag/ingestWebContent', () => ({
@@ -14,6 +15,10 @@ vi.mock('../../rag/ingestWebContent', () => ({
 
 vi.mock('../../rag/rag-service', () => ({
   retrieveChunksByQuery: mocks.retrieveChunksByQueryMock,
+}));
+
+vi.mock('@shared/db/functions/files', () => ({
+  dbGetAllChunks: mocks.dbGetAllChunksMock,
 }));
 
 const user = {
@@ -49,8 +54,19 @@ const relatedFileEntities = [
   },
 ] as FileModel[];
 
+/** More chunks than VECTOR_SEARCH_LIMIT — forces the vector search path */
+const overLimitChunks = Array.from({ length: VECTOR_SEARCH_LIMIT + 1 }, (_, i) => ({
+  fileId: 'file-1',
+  fileName: 'Arbeitsblatt.pdf',
+  sourceUrl: null,
+  orderIndex: i,
+  content: `Chunk ${i}.`,
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: total chunks exceed the limit → vector search path
+  mocks.dbGetAllChunksMock.mockResolvedValue(overLimitChunks);
   mocks.retrieveChunksByQueryMock.mockResolvedValue([
     {
       id: 'chunk-1',
@@ -233,5 +249,202 @@ describe('buildRetrieveTextChunksTool', () => {
     const parsed = JSON.parse(result);
     expect(parsed.chunks).toEqual([]);
     expect(parsed.error).toBe('No matching chunks found.');
+  });
+
+  describe('short-circuit when total chunk count ≤ VECTOR_SEARCH_LIMIT', () => {
+    it('passes both file IDs and processed source URLs to dbGetAllChunks', async () => {
+      mocks.ingestWebContentMock.mockResolvedValueOnce({
+        processedUrls: ['https://example.com/page'],
+        errorUrls: [],
+      });
+
+      const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+      const tool = buildRetrieveTextChunksTool({
+        user,
+        relatedFileEntities,
+        sourceUrls: ['https://example.com/page'],
+        attachedLinks: [],
+      });
+
+      await tool!.handler({ search: 'suche' });
+
+      expect(mocks.dbGetAllChunksMock).toHaveBeenCalledWith({
+        fileIds: ['file-1', 'file-2'],
+        sourceUrls: ['https://example.com/page'],
+        limit: VECTOR_SEARCH_LIMIT + 1,
+      });
+    });
+
+    it('returns all chunks directly without a vector search when total fits within the limit', async () => {
+      mocks.dbGetAllChunksMock.mockResolvedValue([
+        {
+          fileId: 'file-1',
+          fileName: 'Arbeitsblatt.pdf',
+          sourceUrl: null,
+          orderIndex: 0,
+          content: 'Chunk A1.',
+        },
+        {
+          fileId: 'file-1',
+          fileName: 'Arbeitsblatt.pdf',
+          sourceUrl: null,
+          orderIndex: 1,
+          content: 'Chunk A2.',
+        },
+        {
+          fileId: 'file-1',
+          fileName: 'Arbeitsblatt.pdf',
+          sourceUrl: null,
+          orderIndex: 2,
+          content: 'Chunk A3.',
+        },
+        {
+          fileId: 'file-2',
+          fileName: 'Leitfaden.txt',
+          sourceUrl: null,
+          orderIndex: 0,
+          content: 'Chunk B1.',
+        },
+        {
+          fileId: 'file-2',
+          fileName: 'Leitfaden.txt',
+          sourceUrl: null,
+          orderIndex: 1,
+          content: 'Chunk B2.',
+        },
+        {
+          fileId: 'file-2',
+          fileName: 'Leitfaden.txt',
+          sourceUrl: null,
+          orderIndex: 2,
+          content: 'Chunk B3.',
+        },
+        {
+          fileId: 'file-2',
+          fileName: 'Leitfaden.txt',
+          sourceUrl: null,
+          orderIndex: 3,
+          content: 'Chunk B4.',
+        },
+      ]); // total = 7 ≤ VECTOR_SEARCH_LIMIT
+
+      const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+      const tool = buildRetrieveTextChunksTool({
+        user,
+        relatedFileEntities,
+        sourceUrls: [],
+        attachedLinks: [],
+      });
+
+      const result = await tool!.handler({ search: 'irgendwas' });
+      const parsed = JSON.parse(result);
+
+      expect(mocks.retrieveChunksByQueryMock).not.toHaveBeenCalled();
+      expect(parsed.chunks).toHaveLength(7);
+      expect(parsed.error).toBeNull();
+    });
+
+    it('short-circuits for URL-only sources when total fits within the limit', async () => {
+      mocks.ingestWebContentMock.mockResolvedValueOnce({
+        processedUrls: ['https://example.com/page'],
+        errorUrls: [],
+      });
+      mocks.dbGetAllChunksMock.mockResolvedValue([
+        {
+          fileId: null,
+          fileName: null,
+          sourceUrl: 'https://example.com/page',
+          orderIndex: 0,
+          content: 'Web chunk 1.',
+        },
+        {
+          fileId: null,
+          fileName: null,
+          sourceUrl: 'https://example.com/page',
+          orderIndex: 1,
+          content: 'Web chunk 2.',
+        },
+      ]); // total = 2 ≤ VECTOR_SEARCH_LIMIT
+
+      const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+      const tool = buildRetrieveTextChunksTool({
+        user,
+        relatedFileEntities: [],
+        sourceUrls: ['https://example.com/page'],
+        attachedLinks: [],
+      });
+
+      const result = await tool!.handler({ search: 'suche' });
+      const parsed = JSON.parse(result);
+
+      expect(mocks.retrieveChunksByQueryMock).not.toHaveBeenCalled();
+      expect(parsed.chunks).toHaveLength(2);
+      expect(parsed.error).toBeNull();
+    });
+
+    it('still calls vector search when total chunk count exceeds the limit', async () => {
+      // default beforeEach mock already sets total > VECTOR_SEARCH_LIMIT
+      const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+      const tool = buildRetrieveTextChunksTool({
+        user,
+        relatedFileEntities,
+        sourceUrls: [],
+        attachedLinks: [],
+      });
+
+      await tool!.handler({ search: 'suche' });
+
+      expect(mocks.dbGetAllChunksMock).toHaveBeenCalled();
+      expect(mocks.retrieveChunksByQueryMock).toHaveBeenCalled();
+    });
+
+    it('treats the exact limit as small (≤ not <) and skips vector search', async () => {
+      mocks.dbGetAllChunksMock.mockResolvedValue(
+        Array.from({ length: VECTOR_SEARCH_LIMIT }, (_, i) => ({
+          fileId: 'file-1',
+          fileName: 'Arbeitsblatt.pdf',
+          sourceUrl: null,
+          orderIndex: i,
+          content: `Chunk ${i}.`,
+        })),
+      ); // total === VECTOR_SEARCH_LIMIT
+
+      const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+      const tool = buildRetrieveTextChunksTool({
+        user,
+        relatedFileEntities,
+        sourceUrls: [],
+        attachedLinks: [],
+      });
+
+      await tool!.handler({ search: 'suche' });
+
+      expect(mocks.retrieveChunksByQueryMock).not.toHaveBeenCalled();
+      expect(mocks.dbGetAllChunksMock).toHaveBeenCalled();
+    });
+
+    it('returns error when all chunks retrieved directly but result is empty', async () => {
+      mocks.dbGetAllChunksMock.mockResolvedValue([]);
+
+      const { buildRetrieveTextChunksTool } = await import('./retrieve-text-chunks-tool');
+
+      const tool = buildRetrieveTextChunksTool({
+        user,
+        relatedFileEntities,
+        sourceUrls: [],
+        attachedLinks: [],
+      });
+
+      const result = await tool!.handler({ search: 'suche' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.chunks).toEqual([]);
+      expect(parsed.error).toBe('No matching chunks found.');
+    });
   });
 });

--- a/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.ts
@@ -2,6 +2,7 @@ import { VECTOR_SEARCH_LIMIT } from '@/configuration-text-inputs/const';
 import { ingestWebContent } from '../../rag/ingestWebContent';
 import { retrieveChunksByQuery } from '../../rag/rag-service';
 import type { BuildToolsContext, ToolDefinition, ToolRegistration } from './types';
+import { dbGetAllChunks } from '@shared/db/functions/files';
 
 type SemanticFileSearchChunkResult = {
   fileName: string | null;
@@ -82,16 +83,39 @@ export function buildRetrieveTextChunksTool({
 
       processedSourceUrls = processedUrls;
     }
+
     const search = typeof args.search === 'string' ? args.search : '';
-    const chunks = await retrieveChunksByQuery({
-      searchQuery: search,
-      federalStateId: user.federalState.id,
-      relatedFileEntities,
+
+    // Fetch at most VECTOR_SEARCH_LIMIT + 1 chunks to cheaply check whether
+    // the total fits within the limit without pulling the full dataset.
+    const fileIds = relatedFileEntities.map((f) => f.id);
+    const allChunks = await dbGetAllChunks({
+      fileIds,
       sourceUrls: processedSourceUrls,
-      limit: VECTOR_SEARCH_LIMIT,
+      limit: VECTOR_SEARCH_LIMIT + 1,
     });
 
-    return formatRetrievedChunksForTool(chunks);
+    if (allChunks.length <= VECTOR_SEARCH_LIMIT) {
+      const response: SemanticFileSearchToolResponse = {
+        chunks: allChunks.map((chunk) => ({
+          fileName: chunk.fileName,
+          orderIndex: chunk.orderIndex,
+          content: chunk.content,
+        })),
+        error: allChunks.length === 0 ? 'No matching chunks found.' : null,
+      };
+      return JSON.stringify(response);
+    }
+
+    return formatRetrievedChunksForTool(
+      await retrieveChunksByQuery({
+        searchQuery: search,
+        federalStateId: user.federalState.id,
+        relatedFileEntities,
+        sourceUrls: processedSourceUrls,
+        limit: VECTOR_SEARCH_LIMIT,
+      }),
+    );
   };
 
   return { definition, handler };

--- a/packages/shared/src/db/functions/files.ts
+++ b/packages/shared/src/db/functions/files.ts
@@ -1,4 +1,14 @@
-import { and, asc, eq, getTableColumns, inArray, isNotNull, isNull } from 'drizzle-orm';
+import {
+  type SQL,
+  and,
+  asc,
+  eq,
+  getTableColumns,
+  inArray,
+  isNotNull,
+  isNull,
+  or,
+} from 'drizzle-orm';
 import { db } from '..';
 import {
   AssistantFileMapping,
@@ -355,6 +365,48 @@ export async function dbChunksExistForSourceUrls(sourceUrls: string[]): Promise<
     .from(chunkTable)
     .where(inArray(chunkTable.sourceUrl, sourceUrls));
   return new Set(results.map((r) => r.sourceUrl).filter((url): url is string => url !== null));
+}
+
+/**
+ * Returns chunks for the given file IDs and/or source URLs,
+ * ordered by fileId, sourceUrl, orderIndex, id.
+ * Pass `limit` to cap the number of rows returned.
+ */
+export async function dbGetAllChunks({
+  fileIds,
+  sourceUrls,
+  limit,
+}: {
+  fileIds: string[];
+  sourceUrls: string[];
+  limit?: number;
+}) {
+  const conditions: SQL[] = [];
+  if (fileIds.length > 0) {
+    conditions.push(inArray(chunkTable.fileId, fileIds));
+  }
+  if (sourceUrls.length > 0) {
+    conditions.push(inArray(chunkTable.sourceUrl, sourceUrls));
+  }
+  if (conditions.length === 0) return [];
+  const query = db
+    .select({
+      fileId: chunkTable.fileId,
+      fileName: fileTable.name,
+      sourceUrl: chunkTable.sourceUrl,
+      orderIndex: chunkTable.orderIndex,
+      content: chunkTable.content,
+    })
+    .from(chunkTable)
+    .leftJoin(fileTable, eq(chunkTable.fileId, fileTable.id))
+    .where(or(...conditions))
+    .orderBy(
+      asc(chunkTable.fileId),
+      asc(chunkTable.sourceUrl),
+      asc(chunkTable.orderIndex),
+      asc(chunkTable.id),
+    );
+  return limit !== undefined ? query.limit(limit) : query;
 }
 
 export async function dbInsertFile(file: FileInsertModel) {


### PR DESCRIPTION
When the total number of chunks across all attached files and URLs is small enough to fit within `VECTOR_SEARCH_LIMIT`, there is no point in doing an embedding call and a vector search — we already have all the data.

The handler now fetches up to `VECTOR_SEARCH_LIMIT + 1` chunks via a new `dbGetAllChunks` DB function (covers both file IDs and source URLs in one query). If the result fits within the limit it is returned directly; otherwise it is discarded and the existing vector search path runs as before.