### PR TITLE
TD-1389: add local Valkey cluster docker-compose override

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,29 @@ valkey-cli PING
 valkey-cli --stats
 ```
 
+#### Testing Valkey cluster mode locally
+
+To test cluster mode locally, use the override file `docker-compose.valkey-cluster.yml` alongside the base file:
+
+```sh
+docker compose \
+  -f devops/docker/docker-compose.local.yml \
+  -f devops/docker/docker-compose.valkey-cluster.yml \
+  up -d --build
+```
+
+This replaces the standalone Valkey node with a single-node cluster.
+A one-shot `valkey-cluster-init` container bootstraps the cluster automatically on first start.
+
+To reset cluster state, stop only the valkey container and remove its volume:
+
+```sh
+docker compose -f devops/docker/docker-compose.local.yml \
+               -f devops/docker/docker-compose.valkey-cluster.yml \
+               down valkey valkey-cluster-init
+docker volume rm ais-chat_valkey_cluster_data
+```
+
 ## Monitoring
 
 To set up the monitoring and tracing stack in local development, use the following docker compose file:

--- a/devops/docker/docker-compose.valkey-cluster.yml
+++ b/devops/docker/docker-compose.valkey-cluster.yml
@@ -1,0 +1,47 @@
+name: ais-chat
+
+# Override file for a single-node Valkey cluster (cluster mode enabled).
+# Use together with docker-compose.local.yml:
+#
+#   docker compose -f devops/docker/docker-compose.local.yml \
+#                  -f devops/docker/docker-compose.valkey-cluster.yml up -d --build
+#
+# The standalone `valkey` service is replaced by a cluster-enabled node.
+# A one-shot init container bootstraps the cluster after the node is ready.
+
+services:
+  # Override the standalone valkey with a cluster-enabled single node.
+  # Announce 127.0.0.1 since the port is exported to the host — good enough for local dev.
+  valkey:
+    image: ghcr.io/valkey-io/valkey:9.0.4-alpine
+    restart: unless-stopped
+    command: >
+      valkey-server
+      --cluster-enabled yes
+      --cluster-announce-ip 127.0.0.1
+      --cluster-announce-port 6379
+      --appendonly yes
+    volumes: !override
+      - valkey_cluster_data:/data
+    ports: !override
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'valkey-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # One-shot container that bootstraps the single-node cluster.
+  # --cluster-replicas 0 allows a single-node cluster with no replicas.
+  valkey-cluster-init:
+    image: ghcr.io/valkey-io/valkey:9.0.4-alpine
+    restart: no
+    depends_on:
+      valkey:
+        condition: service_healthy
+    entrypoint: >
+      sh -c "valkey-cli --cluster create valkey:6379 --cluster-replicas 0 --cluster-yes"
+
+volumes:
+  valkey_cluster_data:

--- a/packages/shared/src/valkey/index.ts
+++ b/packages/shared/src/valkey/index.ts
@@ -14,6 +14,8 @@ function getClusterDriverOptions(valkeyUrl: string): RedisOptions {
       { host: url.hostname, port: Number(url.port) || 6379 },
     ],
     clusterOptions: {
+      // Disable the offline queue so commands fail fast instead of waiting indefinitely when the cluster is unreachable.
+      enableOfflineQueue: false,
       redisOptions: {
         username: url.username ? decodeURIComponent(url.username) : undefined,
         password: url.password ? decodeURIComponent(url.password) : undefined,


### PR DESCRIPTION
Adds a Docker Compose override file for running Valkey in cluster mode locally. The standalone `valkey` service is replaced by a single-node cluster (all 16384 slots on one node) using `--cluster-announce-ip 127.0.0.1`, which works because the port is exported to the host. A one-shot `valkey-cluster-init` container bootstraps the cluster on first start.

Also disables `enableOfflineQueue` in the cluster driver options so commands fail fast when the cluster is unreachable, and updates the README with usage and reset instructions.