### PR TITLE
TD-1389: remove duplicate Valkey prefix from session constant

### DIFF
--- a/apps/chat-bot/src/auth/session.ts
+++ b/apps/chat-bot/src/auth/session.ts
@@ -1,7 +1,7 @@
 import { logError } from '@shared/logging';
 import { valkey } from '@shared/valkey';
 
-const SESSION_PREFIX = 'ais-chat:app:session:';
+const SESSION_PREFIX = 'session:';
 const TIME_TO_LIVE_SECONDS = 60 * 60 * 24; // remove blocklist items automatically after 24 hours
 
 /** List of outdated sessions because user logged out elsewhere. */


### PR DESCRIPTION
The prefix `ais-chat:app` is already added globally on the valkey connection.