### PR TITLE
fix: make model response assertion case-insensitive

### DIFF
--- a/apps/chat-bot/e2e/tests/external-services/all-models.test.ts
+++ b/apps/chat-bot/e2e/tests/external-services/all-models.test.ts
@@ -21,7 +21,7 @@ llmModels.forEach((modelName) => {
       await page.goto('/');
       await selectDifferentModel(page, modelName);
       await sendMessage(page, 'Antworte mit genau dem Wort "OK".');
-      await expect(page.getByLabel('assistant message 1')).toContainText('OK');
+      await expect(page.getByLabel('assistant message 1')).toContainText(/ok/i);
     },
   );
 });


### PR DESCRIPTION
The "responds to a simple prompt" e2e test asserted the exact substring "OK" in the assistant's reply. Some models (e.g. Mistral Nemo Instruct) respond with lowercase/mixed-case variants like "Okay, verstanden...", causing flaky failures unrelated to actual model correctness.

Changed the assertion to a case-insensitive regex (/ok/i) so the test only checks the model acknowledged with some form of "ok", regardless of casing.