### PR TITLE
TD-1389: chore: bump valkey image to 9.1.0-alpine

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       valkey:
-        image: ghcr.io/valkey-io/valkey:9.0.4-alpine
+        image: ghcr.io/valkey-io/valkey:9.1.0-alpine
         ports:
           - 6379:6379
       rabbitmq:

--- a/devops/docker/docker-compose.local.yml
+++ b/devops/docker/docker-compose.local.yml
@@ -22,7 +22,7 @@ services:
       start_period: 30s
 
   valkey:
-    image: ghcr.io/valkey-io/valkey:9.0.4-alpine
+    image: ghcr.io/valkey-io/valkey:9.1.0-alpine
     restart: unless-stopped
     volumes:
       - valkey_data:/data

--- a/devops/docker/docker-compose.valkey-cluster.yml
+++ b/devops/docker/docker-compose.valkey-cluster.yml
@@ -13,7 +13,7 @@ services:
   # Override the standalone valkey with a cluster-enabled single node.
   # Announce 127.0.0.1 since the port is exported to the host — good enough for local dev.
   valkey:
-    image: ghcr.io/valkey-io/valkey:9.0.4-alpine
+    image: ghcr.io/valkey-io/valkey:9.1.0-alpine
     restart: unless-stopped
     command: >
       valkey-server
@@ -35,7 +35,7 @@ services:
   # One-shot container that bootstraps the single-node cluster.
   # --cluster-replicas 0 allows a single-node cluster with no replicas.
   valkey-cluster-init:
-    image: ghcr.io/valkey-io/valkey:9.0.4-alpine
+    image: ghcr.io/valkey-io/valkey:9.1.0-alpine
     restart: no
     depends_on:
       valkey:

--- a/devops/docker/docker-compose.yml
+++ b/devops/docker/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
   # Valkey (Redis-compatible) for session storage
   valkey:
-    image: ghcr.io/valkey-io/valkey:9.0.4-alpine
+    image: ghcr.io/valkey-io/valkey:9.1.0-alpine
     restart: unless-stopped
     volumes:
       - valkey_data:/data


### PR DESCRIPTION
Bumps the ghcr.io/valkey-io/valkey docker image from 9.0.4-alpine to 9.1.0-alpine across all docker-compose files and the e2e workflow.