### PR TITLE
TD-1421: track shared chat tool costs

### DIFF
--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -150,7 +150,6 @@ export async function sendCharacterMessage({
     const builtTools = await buildTools({
       user: teacherUserAndContext,
       characterId: character.id,
-      conversationId: `shared-character:${character.id}`,
       relatedFileEntities,
       attachedLinks: character.attachedLinks,
       sourceUrls: processedUrls,

--- a/apps/chat-bot/src/app/api/chat/build-tools.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.ts
@@ -11,7 +11,7 @@ type BuildToolsParams = {
   characterId?: string;
   learningScenarioId?: string;
   assistantId?: string;
-  conversationId: string;
+  conversationId?: string;
   relatedFileEntities: FileModel[];
   sourceUrls?: string[];
   attachedLinks?: string[];

--- a/apps/chat-bot/src/app/api/chat/env.ts
+++ b/apps/chat-bot/src/app/api/chat/env.ts
@@ -1,0 +1,12 @@
+import { createEnv } from '@t3-oss/env-nextjs';
+import { z } from 'zod';
+
+export const env = createEnv({
+  emptyStringAsUndefined: true,
+  server: {
+    linkupApiKey: z.string().optional(),
+  },
+  runtimeEnv: {
+    linkupApiKey: process.env.LINKUP_API_KEY,
+  },
+});

--- a/apps/chat-bot/src/app/api/chat/tools/types.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/types.ts
@@ -15,7 +15,7 @@ export type BuildToolsContext = {
   characterId?: string;
   learningScenarioId?: string;
   assistantId?: string;
-  conversationId: string;
+  conversationId?: string;
   relatedFileEntities: FileModel[];
   sourceUrls: string[];
   attachedLinks: string[];

--- a/apps/chat-bot/src/app/api/chat/tools/web-search-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/web-search-tool.ts
@@ -62,6 +62,8 @@ export async function buildWebSearchTool({
     const results = await searchWeb({
       query,
       conversationId,
+      characterId,
+      learningScenarioId,
       userId: user.id,
     });
 

--- a/apps/chat-bot/src/app/api/chat/websearch.test.ts
+++ b/apps/chat-bot/src/app/api/chat/websearch.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  dbGetAssistantByIdMock: vi.fn(),
+  dbGetCharacterByIdMock: vi.fn(),
+  dbGetLearningScenarioByIdMock: vi.fn(),
   dbInsertConversationToolCallUsageMock: vi.fn(),
   dbUpdateTokenUsageByCharacterChatIdMock: vi.fn(),
   dbUpdateTokenUsageBySharedLearningScenarioIdMock: vi.fn(),
@@ -15,6 +18,21 @@ vi.mock('./env', () => ({
   },
 }));
 
+vi.mock('@shared/db/functions/assistants', () => ({
+  dbGetAssistantById: mocks.dbGetAssistantByIdMock,
+}));
+
+vi.mock('@shared/db/functions/character', () => ({
+  dbGetCharacterById: mocks.dbGetCharacterByIdMock,
+  dbUpdateTokenUsageByCharacterChatId: mocks.dbUpdateTokenUsageByCharacterChatIdMock,
+}));
+
+vi.mock('@shared/db/functions/learning-scenario', () => ({
+  dbGetLearningScenarioById: mocks.dbGetLearningScenarioByIdMock,
+  dbUpdateTokenUsageBySharedLearningScenarioId:
+    mocks.dbUpdateTokenUsageBySharedLearningScenarioIdMock,
+}));
+
 vi.mock('linkup-sdk', () => ({
   LinkupClient: vi.fn(function LinkupClient(this: unknown) {
     return {
@@ -25,15 +43,6 @@ vi.mock('linkup-sdk', () => ({
 
 vi.mock('@shared/db/functions/token-usage', () => ({
   dbInsertConversationToolCallUsage: mocks.dbInsertConversationToolCallUsageMock,
-}));
-
-vi.mock('@shared/db/functions/character', () => ({
-  dbUpdateTokenUsageByCharacterChatId: mocks.dbUpdateTokenUsageByCharacterChatIdMock,
-}));
-
-vi.mock('@shared/db/functions/learning-scenario', () => ({
-  dbUpdateTokenUsageBySharedLearningScenarioId:
-    mocks.dbUpdateTokenUsageBySharedLearningScenarioIdMock,
 }));
 
 vi.mock('@shared/db/functions/tool-call', () => ({

--- a/apps/chat-bot/src/app/api/chat/websearch.test.ts
+++ b/apps/chat-bot/src/app/api/chat/websearch.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  dbInsertConversationToolCallUsageMock: vi.fn(),
+  dbUpdateTokenUsageByCharacterChatIdMock: vi.fn(),
+  dbUpdateTokenUsageBySharedLearningScenarioIdMock: vi.fn(),
+  dbGetToolCallCostByNameMock: vi.fn(),
+  searchMock: vi.fn(),
+  generateTextWithBillingMock: vi.fn(),
+}));
+
+vi.mock('@/env', () => ({
+  env: {
+    linkupApiKey: 'linkup-api-key',
+  },
+}));
+
+vi.mock('linkup-sdk', () => ({
+  LinkupClient: vi.fn(function LinkupClient(this: unknown) {
+    return {
+      search: mocks.searchMock,
+    };
+  }),
+}));
+
+vi.mock('@shared/db/functions/token-usage', () => ({
+  dbInsertConversationToolCallUsage: mocks.dbInsertConversationToolCallUsageMock,
+}));
+
+vi.mock('@shared/db/functions/character', () => ({
+  dbUpdateTokenUsageByCharacterChatId: mocks.dbUpdateTokenUsageByCharacterChatIdMock,
+}));
+
+vi.mock('@shared/db/functions/learning-scenario', () => ({
+  dbUpdateTokenUsageBySharedLearningScenarioId:
+    mocks.dbUpdateTokenUsageBySharedLearningScenarioIdMock,
+}));
+
+vi.mock('@shared/db/functions/tool-call', () => ({
+  dbGetToolCallCostByName: mocks.dbGetToolCallCostByNameMock,
+}));
+
+vi.mock('@ais-chat/ai-core', () => ({
+  generateTextWithBilling: mocks.generateTextWithBillingMock,
+}));
+
+describe('searchWeb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.dbGetToolCallCostByNameMock.mockResolvedValue({ costsInCent: 0.42 });
+    mocks.searchMock.mockResolvedValue({
+      results: [
+        {
+          name: 'Result',
+          url: 'https://example.com',
+          content: 'content',
+        },
+      ],
+    });
+  });
+
+  it('records normal chat tool call usage in conversation usage tracking', async () => {
+    const { searchWeb } = await import('./websearch');
+
+    await searchWeb({
+      query: 'aktuelles thema',
+      conversationId: 'conversation-1',
+      userId: 'user-1',
+    });
+
+    expect(mocks.dbInsertConversationToolCallUsageMock).toHaveBeenCalledWith({
+      toolCallName: 'web_search',
+      conversationId: 'conversation-1',
+      userId: 'user-1',
+      costsInCent: 0.42,
+    });
+    expect(mocks.dbUpdateTokenUsageByCharacterChatIdMock).not.toHaveBeenCalled();
+    expect(mocks.dbUpdateTokenUsageBySharedLearningScenarioIdMock).not.toHaveBeenCalled();
+  });
+
+  it('prefers conversation usage tracking when conversationId is present', async () => {
+    const { searchWeb } = await import('./websearch');
+
+    await searchWeb({
+      query: 'aktuelles thema',
+      conversationId: 'conversation-1',
+      userId: 'user-1',
+      characterId: 'character-uuid',
+      learningScenarioId: 'learning-scenario-uuid',
+    });
+
+    expect(mocks.dbInsertConversationToolCallUsageMock).toHaveBeenCalledWith({
+      toolCallName: 'web_search',
+      conversationId: 'conversation-1',
+      userId: 'user-1',
+      costsInCent: 0.42,
+    });
+    expect(mocks.dbUpdateTokenUsageByCharacterChatIdMock).not.toHaveBeenCalled();
+    expect(mocks.dbUpdateTokenUsageBySharedLearningScenarioIdMock).not.toHaveBeenCalled();
+  });
+
+  it('records shared character tool call usage in shared character usage tracking', async () => {
+    const { searchWeb } = await import('./websearch');
+
+    await searchWeb({
+      query: 'aktuelles thema',
+      userId: 'user-1',
+      characterId: 'character-uuid',
+    });
+
+    expect(mocks.dbUpdateTokenUsageByCharacterChatIdMock).toHaveBeenCalledWith({
+      toolCallName: 'web_search',
+      characterId: 'character-uuid',
+      userId: 'user-1',
+      costsInCent: 0.42,
+      completionTokens: 0,
+      promptTokens: 0,
+      modelId: null,
+    });
+    expect(mocks.dbInsertConversationToolCallUsageMock).not.toHaveBeenCalled();
+    expect(mocks.dbUpdateTokenUsageBySharedLearningScenarioIdMock).not.toHaveBeenCalled();
+  });
+
+  it('records shared learning scenario tool call usage in shared learning scenario usage tracking', async () => {
+    const { searchWeb } = await import('./websearch');
+
+    await searchWeb({
+      query: 'aktuelles thema',
+      userId: 'user-1',
+      learningScenarioId: 'learning-scenario-uuid',
+    });
+
+    expect(mocks.dbUpdateTokenUsageBySharedLearningScenarioIdMock).toHaveBeenCalledWith({
+      toolCallName: 'web_search',
+      learningScenarioId: 'learning-scenario-uuid',
+      userId: 'user-1',
+      costsInCent: 0.42,
+      completionTokens: 0,
+      promptTokens: 0,
+      modelId: null,
+    });
+    expect(mocks.dbInsertConversationToolCallUsageMock).not.toHaveBeenCalled();
+    expect(mocks.dbUpdateTokenUsageByCharacterChatIdMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/chat-bot/src/app/api/chat/websearch.test.ts
+++ b/apps/chat-bot/src/app/api/chat/websearch.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   generateTextWithBillingMock: vi.fn(),
 }));
 
-vi.mock('@/env', () => ({
+vi.mock('./env', () => ({
   env: {
     linkupApiKey: 'linkup-api-key',
   },

--- a/apps/chat-bot/src/app/api/chat/websearch.ts
+++ b/apps/chat-bot/src/app/api/chat/websearch.ts
@@ -1,6 +1,6 @@
 import { LinkupClient } from 'linkup-sdk';
 import { generateTextWithBilling, type Message } from '@ais-chat/ai-core';
-import { env } from '@/env';
+import { env } from './env';
 import {
   WEBSEARCH_RESULT_LENGTH_LIMIT,
   WEBSEARCH_RESULTS_LIMIT,

--- a/apps/chat-bot/src/app/api/chat/websearch.ts
+++ b/apps/chat-bot/src/app/api/chat/websearch.ts
@@ -8,6 +8,8 @@ import {
 import type { WebSearchResult } from '@shared/db/schema';
 import { logError } from '@shared/logging';
 import { dbInsertConversationToolCallUsage } from '@shared/db/functions/token-usage';
+import { dbUpdateTokenUsageByCharacterChatId } from '@shared/db/functions/character';
+import { dbUpdateTokenUsageBySharedLearningScenarioId } from '@shared/db/functions/learning-scenario';
 import { dbGetToolCallCostByName } from '@shared/db/functions/tool-call';
 import { formatDateToGermanTimestamp } from '@shared/utils/date';
 import { UserAndContext } from '@/auth/types';
@@ -47,9 +49,13 @@ export async function isWebSearchEnabled({
 
 async function recordWebSearchUsage({
   conversationId,
+  characterId,
+  learningScenarioId,
   userId,
 }: {
-  conversationId: string;
+  conversationId?: string;
+  characterId?: string;
+  learningScenarioId?: string;
   userId: string;
 }) {
   let costsInCent = 0;
@@ -61,12 +67,34 @@ async function recordWebSearchUsage({
   }
 
   try {
-    await dbInsertConversationToolCallUsage({
-      toolCallName: 'web_search',
-      conversationId,
-      userId,
-      costsInCent,
-    });
+    if (conversationId) {
+      await dbInsertConversationToolCallUsage({
+        toolCallName: 'web_search',
+        conversationId,
+        userId,
+        costsInCent,
+      });
+    } else if (characterId) {
+      await dbUpdateTokenUsageByCharacterChatId({
+        toolCallName: 'web_search',
+        characterId,
+        userId,
+        costsInCent,
+        completionTokens: 0,
+        promptTokens: 0,
+        modelId: null,
+      });
+    } else if (learningScenarioId) {
+      await dbUpdateTokenUsageBySharedLearningScenarioId({
+        toolCallName: 'web_search',
+        learningScenarioId,
+        userId,
+        costsInCent,
+        completionTokens: 0,
+        promptTokens: 0,
+        modelId: null,
+      });
+    }
   } catch (error) {
     logError('Error recording web search usage billing.', error);
   }
@@ -167,15 +195,23 @@ Beispiele:
  * Search results can be used in the rag context of the system prompt.
  *
  * @param query The search query string.
+ * @param conversationId Optional conversation ID.
+ * @param characterId Optional character ID.
+ * @param learningScenarioId Optional learning scenario ID.
+ * @param userId The user ID.
  * @returns An array of text search results from the Linkup API.
  */
 export async function searchWeb({
   query,
   conversationId,
+  characterId,
+  learningScenarioId,
   userId,
 }: {
   query: string;
-  conversationId: string;
+  conversationId?: string;
+  characterId?: string;
+  learningScenarioId?: string;
   userId: string;
 }): Promise<WebSearchResult[]> {
   if (!env.linkupApiKey) {
@@ -196,6 +232,8 @@ export async function searchWeb({
 
     await recordWebSearchUsage({
       conversationId,
+      characterId,
+      learningScenarioId,
       userId,
     });
 
@@ -220,10 +258,11 @@ export async function searchWeb({
  * @param messages - The conversation message history used to determine search necessity.
  * @param user - The authenticated user and their context, including federal state feature toggles.
  * @param characterId - Optional character ID
+ * @param learningScenarioId - Optional learning scenario ID
  * @param assistantId - Optional assistant ID
  * @param modelId - The ID of the auxiliary model used for the search classification.
  * @param apiKeyId - The API key ID of the auxiliary model.
- * @param conversationId - The conversation ID.
+ * @param conversationId - Optional conversation ID.
  * @returns An array of web search results, or an empty array if search is disabled or not needed.
  */
 export async function runWebSearchPipeline({
@@ -243,7 +282,7 @@ export async function runWebSearchPipeline({
   assistantId?: string;
   modelId: string;
   apiKeyId: string;
-  conversationId: string;
+  conversationId?: string;
 }): Promise<WebSearchResult[]> {
   const enabled = await isWebSearchEnabled({
     user,
@@ -256,5 +295,11 @@ export async function runWebSearchPipeline({
   const decision = await isWebSearchNeeded({ messages, modelId, apiKeyId });
   if (!decision.needed) return [];
 
-  return searchWeb({ query: decision.query, conversationId, userId: user.id });
+  return searchWeb({
+    query: decision.query,
+    conversationId,
+    characterId,
+    learningScenarioId,
+    userId: user.id,
+  });
 }

--- a/apps/chat-bot/src/app/api/chat/websearch.ts
+++ b/apps/chat-bot/src/app/api/chat/websearch.ts
@@ -94,6 +94,8 @@ async function recordWebSearchUsage({
         promptTokens: 0,
         modelId: null,
       });
+    } else {
+      logError('Missing billing context for web search usage tracking');
     }
   } catch (error) {
     logError('Error recording web search usage billing.', error);

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -155,7 +155,6 @@ export async function sendLearningScenarioMessage({
     const builtTools = await buildTools({
       user: teacherUserAndContext,
       learningScenarioId: learningScenario.id,
-      conversationId: `shared-learning-scenario:${learningScenario.id}`,
       relatedFileEntities,
       attachedLinks: learningScenario.attachedLinks,
       sourceUrls: processedUrls,

--- a/apps/chat-bot/src/env.ts
+++ b/apps/chat-bot/src/env.ts
@@ -20,7 +20,6 @@ export const env = createEnv({
     crawl4AIUrl: z.url().default('http://localhost:11235'),
     crawl4AIToken: z.string().optional(),
     xbergUrl: z.url().default('http://localhost:8000'),
-    linkupApiKey: z.string().optional(),
   },
   runtimeEnv: {
     apiKey: process.env.API_KEY,
@@ -39,6 +38,5 @@ export const env = createEnv({
     crawl4AIUrl: process.env.CRAWL4AI_URL,
     crawl4AIToken: process.env.CRAWL4AI_API_TOKEN,
     xbergUrl: process.env.XBERG_URL,
-    linkupApiKey: process.env.LINKUP_API_KEY,
   },
 });


### PR DESCRIPTION
Track websearch tool-call costs for shared chats in the shared usage tables instead of the normal conversation usage table.

This keeps teacher chats on the normal conversation path while shared character and learning-scenario chats record tool costs in their own usage tracking tables. Added a regression test for the routing behavior.