### PR TITLE
TD-1400: Migrate kreuzberg to xberg 1.0.0-rc.29-core, add .odp support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,11 +51,11 @@ jobs:
           RABBITMQ_DEFAULT_PASS: password
           RABBITMQ_DEFAULT_USER: user
       xberg:
-        image: ghcr.io/xberg-io/kreuzberg:4.9.9-core
+        image: ghcr.io/xberg-io/xberg:1.0.0-rc.29-core
         ports:
           - 8000:8000
         env:
-          KREUZBERG_MAX_UPLOAD_SIZE_MB: '50'
+          XBERG_MAX_UPLOAD_SIZE_MB: '50'
         options: >-
           --health-cmd "curl -f http://localhost:8000/health"
           --health-interval 30s

--- a/apps/chat-bot/src/app/api/file-extraction/file-extraction-xberg.ts
+++ b/apps/chat-bot/src/app/api/file-extraction/file-extraction-xberg.ts
@@ -1,8 +1,16 @@
+import { z } from 'zod';
 import { env } from '@/env';
 
-interface XbergResult {
-  content: string;
-}
+const xbergResultSchema = z.object({
+  content: z.string(),
+});
+
+// The xberg service historically returned a top-level array of results, and now
+// returns an object with a `results` key. Support both, normalizing to the new shape.
+const xbergResponseSchema = z.union([
+  z.array(xbergResultSchema).transform((results) => ({ results })),
+  z.object({ results: z.array(xbergResultSchema) }),
+]);
 
 /**
  * Extracts text from a file as Markdown using the xberg-io extraction service.
@@ -32,8 +40,10 @@ export async function fileExtractionXberg({
       throw new Error(`Xberg request failed with status ${response.status} for file: ${filename}`);
     }
 
-    const results = (await response.json()) as XbergResult[];
-    const markdown = results?.[0]?.content?.trim() ?? '';
+    const json = await response.json();
+    const { results } = xbergResponseSchema.parse(json);
+
+    const markdown = results[0]?.content?.trim() ?? '';
 
     if (!markdown) {
       throw new Error(`Xberg returned no content for file: ${filename}`);

--- a/apps/chat-bot/src/components/icons/file-upload-icons/file-icons-dict.tsx
+++ b/apps/chat-bot/src/components/icons/file-upload-icons/file-icons-dict.tsx
@@ -25,6 +25,7 @@ export const FILE_ICONS_DICT: Record<SupportedDocumentExtension, FileIconConfig>
   html: { Icon: FileHtmlIcon, fillColor: '#9532C0' },
   md: { Icon: FileMdIcon, fillColor: '#000000' },
   ods: { Icon: FileXlsIcon, fillColor: '#107C42' },
+  odp: { Icon: FilePptIcon, fillColor: '#C0391B' },
   odt: { Icon: FileDocIcon, fillColor: '#1A59C0' },
   pdf: { Icon: FilePdfIcon, fillColor: '#B30B00' },
   pptx: { Icon: FilePptIcon, fillColor: '#C0391B' },

--- a/apps/chat-bot/src/const.ts
+++ b/apps/chat-bot/src/const.ts
@@ -1,19 +1,20 @@
 export const SUPPORTED_DOCUMENTS_EXTENSIONS = [
-  'docx',
-  'pdf',
-  'md',
-  'txt',
-  'pptx',
   'csv',
-  'xlsx',
+  'docx',
+  'htm',
+  'html',
+  'md',
+  'odp',
   'ods',
   'odt',
+  'pdf',
+  'pptx',
   'tex',
-  'html',
-  'htm',
+  'txt',
+  'xlsx',
 ] as const;
 
-export const SUPPORTED_IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp', 'svg'] as const;
+export const SUPPORTED_IMAGE_EXTENSIONS = ['jpeg', 'jpg', 'png', 'svg', 'webp'] as const;
 
 export const SUPPORTED_FILE_EXTENSIONS = [
   ...SUPPORTED_DOCUMENTS_EXTENSIONS,

--- a/devops/docker/docker-compose.local.yml
+++ b/devops/docker/docker-compose.local.yml
@@ -98,13 +98,13 @@ services:
       start_period: 40s
 
   xberg:
-    image: ghcr.io/xberg-io/kreuzberg:4.9.9-core
+    image: ghcr.io/xberg-io/xberg:1.0.0-rc.29-core
     environment:
-      KREUZBERG_MAX_UPLOAD_SIZE_MB: '50'
+      XBERG_MAX_UPLOAD_SIZE_MB: '50'
     ports:
       - '8000:8000'
     volumes:
-      - xberg_cache:/app/.kreuzberg
+      - xberg_cache:/app/.xberg
     restart: unless-stopped
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/health']

--- a/devops/docker/docker-compose.yml
+++ b/devops/docker/docker-compose.yml
@@ -107,16 +107,16 @@ services:
       retries: 3
       start_period: 40s
 
-  # Kreuzberg text extraction service
+  # Xberg text extraction service
   xberg:
-    image: ghcr.io/xberg-io/kreuzberg:4.9.9-core
+    image: ghcr.io/xberg-io/xberg:1.0.0-rc.29-core
     restart: unless-stopped
     environment:
-      KREUZBERG_MAX_UPLOAD_SIZE_MB: '50'
+      XBERG_MAX_UPLOAD_SIZE_MB: '50'
     ports:
       - '8000:8000'
     volumes:
-      - xberg_cache:/app/.kreuzberg
+      - xberg_cache:/app/.xberg
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://127.0.0.1:8000/health']
       interval: 30s
@@ -228,7 +228,7 @@ services:
       CRAWL4AI_URL: http://crawl4ai:11235
       CRAWL4AI_API_TOKEN: ais-chat-crawl4ai-token
 
-      # Kreuzberg text extraction
+      # Xberg text extraction
       XBERG_URL: http://xberg:8000
 
       # S3 Object Storage for file uploads and image generation


### PR DESCRIPTION
Migrates the self-hosted text extraction service from Kreuzberg 4.9.9 to xberg 1.0.0-rc.29-core, updating the Docker image reference, environment variable name (`KREUZBERG_MAX_UPLOAD_SIZE_MB` → `XBERG_MAX_UPLOAD_SIZE_MB`), and cache volume path (`/app/.kreuzberg` → `/app/.xberg`) across both docker-compose files and the e2e CI workflow. All remaining "kreuzberg" references in the repo have been renamed to "xberg"; the app-facing code (env schema, client wrapper, tests) was already consistently named `xberg`.

Also adds `.odp` (OpenDocument Presentation) as a supported document upload extension, alongside the existing `.odt`/`.ods` OpenDocument formats, so it now appears in the upload button's accepted file types, drag-and-drop area, and the system prompt shown to the LLM.