### PR TITLE
chore: improve file extension error message for better clarity

### DIFF
--- a/apps/chat-bot/src/utils/files/generic.ts
+++ b/apps/chat-bot/src/utils/files/generic.ts
@@ -5,11 +5,11 @@ import {
 } from '@/const';
 
 export function getFileExtension(fileName: string) {
-  const lastPart = fileName.split('.').at(-1)?.toLowerCase();
-  if (lastPart === undefined || !isSupportedFileExtension(lastPart)) {
-    throw new Error('file type is not supported or missing');
+  const fileExtension = fileName.split('.').at(-1)?.toLowerCase();
+  if (!fileExtension || !isSupportedFileExtension(fileExtension)) {
+    throw new Error(`file type ${fileExtension} is not supported`);
   }
-  return lastPart;
+  return fileExtension;
 }
 
 export function isImageFile(fileName: string): boolean {


### PR DESCRIPTION
This pull request makes a small improvement to the `getFileExtension` function in `apps/chat-bot/src/utils/files/generic.ts`. The error message now includes the unsupported file extension for clearer debugging, and variable naming is slightly improved for clarity. No other functional changes are introduced.