### PR TITLE
TD-1434: nudge model to check background knowledge before answering

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,17 +50,6 @@ jobs:
         env:
           RABBITMQ_DEFAULT_PASS: password
           RABBITMQ_DEFAULT_USER: user
-      xberg:
-        image: ghcr.io/xberg-io/xberg:1.0.0-rc.29-core
-        ports:
-          - 8000:8000
-        env:
-          XBERG_MAX_UPLOAD_SIZE_MB: '50'
-        options: >-
-          --health-cmd "curl -f http://localhost:8000/health"
-          --health-interval 30s
-          --health-timeout 10s
-          --health-retries 3
 
     env:
       DATABASE_URL: postgresql://admin:test1234@127.0.0.1:5432/app_db
@@ -85,6 +74,7 @@ jobs:
       TURBO_TELEMETRY_DISABLED: 1
       CRAWL4AI_API_TOKEN: ais-chat-crawl4ai-token
       XBERG_URL: http://localhost:8000
+      XBERG_MAX_UPLOAD_SIZE_MB: '50'
 
     steps:
       - name: Checkout code
@@ -110,6 +100,15 @@ jobs:
             -p 11235:11235 \
             -e CRAWL4AI_API_TOKEN=$CRAWL4AI_API_TOKEN \
             unclecode/crawl4ai:0.9.2 > /tmp/crawl4ai.log 2>&1 &
+
+      # xberg is not started under services because its startup time would delay the whole pipeline
+      - name: Start xberg container (in background)
+        run: |
+          docker run \
+            --name xberg \
+            -p 8000:8000 \
+            -e XBERG_MAX_UPLOAD_SIZE_MB=$XBERG_MAX_UPLOAD_SIZE_MB \
+            ghcr.io/xberg-io/xberg:1.0.0-rc.29-core > /tmp/xberg.log 2>&1 &
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -244,6 +243,12 @@ jobs:
         run: |
           echo "=== crawl4ai logs ==="
           cat /tmp/crawl4ai.log || true
+
+      - name: Print xberg logs
+        if: always()
+        run: |
+          echo "=== xberg logs ==="
+          cat /tmp/xberg.log || true
 
       - name: Print mock-llm logs
         if: always()

--- a/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.ts
@@ -57,7 +57,12 @@ export function buildRetrieveTextChunksTool({
 
   const definition: ToolDefinition = {
     name: 'retrieve_text_chunks',
-    description: `Retrieve relevant text chunks from the attached sources. Available files right now: ${attachedFileDescriptions.join(', ') || 'none'}. Available linked pages right now: ${attachedSourceUrls.join(', ') || 'none'}. Use this tool when you need exact passages from the files or linked pages or want to inspect a specific topic inside the available sources. Returns up to ${VECTOR_SEARCH_LIMIT} chunks per call. Call it with a short, specific search string in the same language as the user.`,
+    description:
+      'Retrieve relevant text chunks from the attached sources. ' +
+      `Available files right now: ${attachedFileDescriptions.join(', ') || 'none'}. Available linked pages right now: ${attachedSourceUrls.join(', ') || 'none'}. ` +
+      'Use this tool when you need exact passages from the files or linked pages or want to inspect a specific topic inside the available sources. ' +
+      "Call this tool BEFORE answering or claiming you don't know something, whenever the question could relate to the sources' topic. " +
+      `Returns up to ${VECTOR_SEARCH_LIMIT} chunks per call. Call it with a short, specific search string in the same language as the user.`,
     parameters: {
       type: 'object',
       properties: {

--- a/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/retrieve-text-chunks-tool.ts
@@ -59,8 +59,9 @@ export function buildRetrieveTextChunksTool({
     name: 'retrieve_text_chunks',
     description:
       'Retrieve relevant text chunks from the attached sources. ' +
-      `Available files right now: ${attachedFileDescriptions.join(', ') || 'none'}. Available linked pages right now: ${attachedSourceUrls.join(', ') || 'none'}. ` +
-      'Use this tool when you need exact passages from the files or linked pages or want to inspect a specific topic inside the available sources. ' +
+      `${attachedFileDescriptions.length > 0 ? `Available files right now: ${attachedFileDescriptions.join(', ')}.` : ''} ` +
+      `${attachedSourceUrls.length > 0 ? `Available linked web pages right now: ${attachedSourceUrls.join(', ')}.` : ''} ` +
+      'Use this tool when you need exact passages from the files or linked web pages or want to inspect a specific topic inside the available sources. ' +
       "Call this tool BEFORE answering or claiming you don't know something, whenever the question could relate to the sources' topic. " +
       `Returns up to ${VECTOR_SEARCH_LIMIT} chunks per call. Call it with a short, specific search string in the same language as the user.`,
     parameters: {

--- a/apps/chat-bot/src/app/api/utils/system-prompt.ts
+++ b/apps/chat-bot/src/app/api/utils/system-prompt.ts
@@ -22,8 +22,14 @@ export function constructToolGuidelines(activeTools: ToolDefinition[]) {
   const sections = ['\n## Fähigkeiten und Einschränkungen'];
 
   if (hasTool(activeTools, 'retrieve_text_chunks')) {
+    const supportedExtensions = [...SUPPORTED_DOCUMENTS_EXTENSIONS, ...SUPPORTED_IMAGE_EXTENSIONS]
+      .map((ext) => ext.toUpperCase())
+      .join(', ');
+
     sections.push(
-      `- Du kannst **Dateien lesen**, die die Nutzerin oder der Nutzer hochgeladen hat. Unterstützt sind nur: ${[...SUPPORTED_DOCUMENTS_EXTENSIONS, ...SUPPORTED_IMAGE_EXTENSIONS].map((ext) => ext.toUpperCase()).join(', ')}. Biete niemals an, andere Formate zu verarbeiten. Der Inhalt dieser Dateien steht dir zur Verfügung.`,
+      '- **Bei der ersten Nachricht:** Wenn Dateien oder Links vorhanden sind, rufe möglichst zuerst `retrieve_text_chunks` auf, bevor du antwortest.',
+      `- Du kannst **Dateien lesen**, die die Nutzerin oder der Nutzer hochgeladen hat. Unterstützt sind nur: ${supportedExtensions}. Biete niemals an, andere Formate zu verarbeiten. Der Inhalt dieser Dateien steht dir zur Verfügung. ` +
+        'Wenn eine Frage zum Thema des Chats oder der hochgeladenen Quellen passen könnte, rufe **zuerst** `retrieve_text_chunks` auf, um zu prüfen, ob die Antwort dort enthalten ist, **bevor** du antwortest oder sagst, dass du etwas nicht weißt.',
     );
   }
 

--- a/apps/chat-bot/src/app/api/utils/system-prompt.ts
+++ b/apps/chat-bot/src/app/api/utils/system-prompt.ts
@@ -28,8 +28,7 @@ export function constructToolGuidelines(activeTools: ToolDefinition[]) {
 
     sections.push(
       '- **Bei der ersten Nachricht:** Wenn Dateien oder Links vorhanden sind, rufe möglichst zuerst `retrieve_text_chunks` auf, bevor du antwortest.',
-      `- Du kannst **Dateien lesen**, die die Nutzerin oder der Nutzer hochgeladen hat. Unterstützt sind nur: ${supportedExtensions}. Biete niemals an, andere Formate zu verarbeiten. ` +
-        'Wenn eine Frage zum Thema des Chats oder der hochgeladenen Quellen passen könnte, rufe **zuerst** `retrieve_text_chunks` auf, um zu prüfen, ob die Antwort dort enthalten ist, **bevor** du antwortest oder sagst, dass du etwas nicht weißt.',
+      `- Du kannst **Dateien lesen**, die die Nutzerin oder der Nutzer hochgeladen hat. Unterstützt sind nur: ${supportedExtensions}. Biete niemals an, andere Formate zu verarbeiten.`,
     );
   }
 

--- a/apps/chat-bot/src/app/api/utils/system-prompt.ts
+++ b/apps/chat-bot/src/app/api/utils/system-prompt.ts
@@ -28,7 +28,7 @@ export function constructToolGuidelines(activeTools: ToolDefinition[]) {
 
     sections.push(
       '- **Bei der ersten Nachricht:** Wenn Dateien oder Links vorhanden sind, rufe möglichst zuerst `retrieve_text_chunks` auf, bevor du antwortest.',
-      `- Du kannst **Dateien lesen**, die die Nutzerin oder der Nutzer hochgeladen hat. Unterstützt sind nur: ${supportedExtensions}. Biete niemals an, andere Formate zu verarbeiten. Der Inhalt dieser Dateien steht dir zur Verfügung. ` +
+      `- Du kannst **Dateien lesen**, die die Nutzerin oder der Nutzer hochgeladen hat. Unterstützt sind nur: ${supportedExtensions}. Biete niemals an, andere Formate zu verarbeiten. ` +
         'Wenn eine Frage zum Thema des Chats oder der hochgeladenen Quellen passen könnte, rufe **zuerst** `retrieve_text_chunks` auf, um zu prüfen, ob die Antwort dort enthalten ist, **bevor** du antwortest oder sagst, dass du etwas nicht weißt.',
     );
   }


### PR DESCRIPTION
Bug: the model would sometimes claim it doesn't know something without first checking the attached background knowledge, unless the student explicitly referenced it.

This strengthens the `retrieve_text_chunks` tool description and the learning-scenario/chat system prompt guidelines so the model is nudged to call the tool before answering when the question could relate to the attached sources' topic, and prefers calling it on the first message of a new conversation when files/links are attached.

Prompt-only change (no code logic changes), so behavior isn't deterministic - verified manually.