### PR TITLE
feat: Bundesland als regionalen Kontext an das Modell geben

### DIFF
--- a/apps/chat-bot/src/app/api/chat/system-prompt.ts
+++ b/apps/chat-bot/src/app/api/chat/system-prompt.ts
@@ -18,12 +18,14 @@ import {
   SUGGESTION_GUIDELINES,
 } from '../utils/system-prompt';
 import type { ToolDefinition } from '@ais-chat/ai-core';
+import { constructFederalStateContext } from '../utils/federal-state-context';
 
 function constructAisChatSystemPrompt(
   chunks: RetrievedChunk[],
   errorUrls: string[],
   webSearchResults: WebSearchResult[],
   activeToolDefinitions: ToolDefinition[],
+  federalStateId: string,
 ) {
   const ragContext = constructRagContext(chunks, errorUrls, webSearchResults);
 
@@ -32,6 +34,7 @@ Du unterstützt Lehrkräfte bei der Unterrichtsgestaltung und Schülerinnen und 
 Du wirst vom FWU, dem Medieninstitut der Länder, entwickelt und betrieben. 
 Heute ist der ${formatDateToGermanTimestamp(new Date())}.
 ${LANGUAGE_GUIDELINES}
+${constructFederalStateContext(federalStateId)}
 ${constructToolGuidelines(activeToolDefinitions)}
 ${FORMAT_GUIDELINES}
 ${SUGGESTION_GUIDELINES}
@@ -44,12 +47,14 @@ function constructAssistantSystemPrompt(
   errorUrls: string[],
   webSearchResults: WebSearchResult[] = [],
   activeToolDefinitions: ToolDefinition[] = [],
+  federalStateId: string = '',
 ) {
   const ragContext = constructRagContext(chunks, errorUrls, webSearchResults);
 
   return `Du bist ein hilfreicher Assistent, der in einer Schule eingesetzt wird, um eine Lehrkraft zu unterstützen. Dein Name ist ${assistant.name}.
 
 ${LANGUAGE_GUIDELINES}
+${constructFederalStateContext(federalStateId)}
 ${constructToolGuidelines(activeToolDefinitions)}
 ${FORMAT_GUIDELINES}
 ${SUGGESTION_GUIDELINES}
@@ -183,8 +188,15 @@ export function constructChatSystemPrompt({
       errorUrls,
       webSearchResults,
       activeToolDefinitions,
+      federalState.id,
     );
   }
 
-  return constructAisChatSystemPrompt(chunks, errorUrls, webSearchResults, activeToolDefinitions);
+  return constructAisChatSystemPrompt(
+    chunks,
+    errorUrls,
+    webSearchResults,
+    activeToolDefinitions,
+    federalState.id,
+  );
 }

--- a/apps/chat-bot/src/app/api/utils/federal-state-context.test.ts
+++ b/apps/chat-bot/src/app/api/utils/federal-state-context.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { constructFederalStateContext } from './federal-state-context';
+
+describe('constructFederalStateContext', () => {
+  it('names the federal state the user works in', () => {
+    expect(constructFederalStateContext('DE-BY')).toContain('Bayern (Freistaat)');
+  });
+
+  it('resolves each supported federal state to a readable name', () => {
+    expect(constructFederalStateContext('DE-NW')).toContain('Nordrhein-Westfalen');
+    expect(constructFederalStateContext('DE-SH')).toContain('Schleswig-Holstein');
+  });
+
+  it('returns nothing for an unknown federal state rather than a placeholder', () => {
+    expect(constructFederalStateContext('DE-XX')).toBe('');
+    expect(constructFederalStateContext('')).toBe('');
+  });
+
+  it('never leaks the unknown-state fallback wording into a prompt', () => {
+    expect(constructFederalStateContext('nonsense')).not.toContain('Unbekanntes Bundesland');
+  });
+
+  it('instructs the model not to assert curriculum details it is unsure about', () => {
+    const context = constructFederalStateContext('DE-BY');
+
+    expect(context).toContain('nur, wenn du sie sicher weißt');
+    expect(context).toContain('Erfinde keine Lehrplanbezeichnungen');
+  });
+
+  it('explains that curricula are a state matter', () => {
+    expect(constructFederalStateContext('DE-HE')).toContain('Ländersache');
+  });
+});

--- a/apps/chat-bot/src/app/api/utils/federal-state-context.ts
+++ b/apps/chat-bot/src/app/api/utils/federal-state-context.ts
@@ -1,0 +1,22 @@
+import { FEDERAL_STATE_NAMES } from '@/utils/vidis/const';
+
+/**
+ * States which federal state the user works in, so answers can account for regional differences.
+ *
+ * Deliberately stops short of asserting curriculum knowledge. Curricula are state-specific and
+ * models reproduce them unreliably, so a confidently wrong Lehrplan reference is worse for a
+ * school product than no reference at all. Authoritative curriculum data is expected to arrive
+ * through the planned MEM MCP server; until then the model only learns *where* it is being used.
+ */
+export function constructFederalStateContext(federalStateId: string) {
+  const federalStateName = (FEDERAL_STATE_NAMES as Record<string, string>)[federalStateId];
+
+  if (federalStateName === undefined) return '';
+
+  return `
+## Regionaler Kontext
+Dein Gegenüber nutzt AIS.chat in ${federalStateName}.
+- Lehrpläne, Fächerbezeichnungen, Schularten und Prüfungsformate sind in Deutschland Ländersache. Richte dich nach den Gepflogenheiten dieses Landes, wenn du Unterrichtsmaterial, Aufgaben oder Bewertungshinweise erstellst.
+- Nenne konkrete Lehrplaninhalte, Kompetenzbereiche oder Jahrgangszuordnungen nur, wenn du sie sicher weißt. Andernfalls benenne die Unsicherheit und weise darauf hin, dass die Angaben am aktuellen Lehrplan des Landes zu prüfen sind.
+- Erfinde keine Lehrplanbezeichnungen, Paragrafen oder Vorschriften.`;
+}


### PR DESCRIPTION
## JIRA Ticket

_Noch offen — bitte TD-Nummer ergänzen, Commit-Message und Branch werden dann angepasst._

## Summary

Das Bundesland war der Anwendung längst bekannt, hat das Modell aber nie erreicht. Es steuerte bisher ausschließlich Infrastruktur: verfügbare LLM-Modelle, Budgetgrenzen, Feature-Toggles, API-Keys, Whitelabel-Branding. Der einzige System-Prompt, der `federalState` überhaupt anfasste, war der Hilfe-Chat — und dort nur für Support-Mailadressen und Speicherdauer, nicht für die Identität des Landes.

Praktisch hieß das: Eine Lehrkraft in Bayern, die ein Arbeitsblatt für Mathematik Klasse 8 anfordert, bekam kein Signal, dass Lehrpläne, Fächerbezeichnungen, Schularten und Prüfungsformate Ländersache sind. Eine vollständige Namenszuordnung (`DE-BY` → „Bayern (Freistaat)") existierte bereits in `utils/vidis/const.ts`, wurde aber an genau einer Stelle verwendet: in der Fehlermeldung bei fehlender Pflichtschulung.

**Der Block behauptet bewusst kein Lehrplanwissen.** Modelle geben Länder-Lehrpläne unzuverlässig wieder, und ein selbstbewusst formulierter falscher Lehrplanbezug ist in einem Schulprodukt schlechter als gar keiner. Der Prompt benennt daher nur das Land, bittet um Orientierung an dessen Gepflogenheiten und verbietet ausdrücklich das Erfinden von Lehrplanbezeichnungen, Paragrafen oder Vorschriften. Belastbare Lehrplandaten sollen über den geplanten **MEM-MCP-Server** kommen; bis dahin erfährt das Modell nur, *wo* es eingesetzt wird.

Gilt für den Standard-Chat und für Assistenten. Dialogpartner bleiben außen vor, weil ein regionaler Hinweis dort die Rollenspiel-Persona bricht; Lernszenarien ebenfalls, weil sie anonym über einen separaten Service mit Schülerinnen und Schülern geteilt werden und sich das Verhalten sonst zwischen Lehrkraft-Vorschau und geteiltem Chat unterscheiden würde. Beides gern als Folgefrage, falls ihr das anders wollt.

Bei unbekannter Bundesland-ID entfällt der Block ersatzlos — der Fallback „Unbekanntes Bundesland" landet nie im Prompt.

Der Helper liegt in einem eigenen Modul statt in `system-prompt.ts`. Letzteres zieht transitiv die Env-Validierung von `api-database` und lässt sich in dieser Umgebung nicht isoliert testen; das eigene Modul importiert nur die Namenszuordnung und ist damit unit-testbar.

6 Unit-Tests. `format`, `lint` und `check-types` grün. Von den Tests der chat-bot-App laufen 25 von 29 Dateien durch; die 4 Failures sind vorbestehend (fehlende Env-Variablen im Container) und auch ohne diese Änderung reproduzierbar.

## Screenshots (if appropriate)

Keine — die Änderung betrifft ausschließlich den System-Prompt und hat keine sichtbare Oberfläche.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNEJfkAxHGU8ciFMqULTMF)_