### PR TITLE
fix(devops): pull bifrost image from ghcr.io

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,7 +117,7 @@ jobs:
             --network host \
             -e APP_HOST=0.0.0.0 \
             -e APP_PORT=8089 \
-            maximhq/bifrost:v1.6.7 > /tmp/bifrost.log 2>&1 &
+            ghcr.io/maximhq/bifrost:v1.6.7 > /tmp/bifrost.log 2>&1 &
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/devops/docker/docker-compose.local.yml
+++ b/devops/docker/docker-compose.local.yml
@@ -120,7 +120,7 @@ services:
       - '6556:6556'
 
   bifrost:
-    image: maximhq/bifrost:v1.6.7
+    image: ghcr.io/maximhq/bifrost:v1.6.7
     restart: unless-stopped
     environment:
       APP_HOST: 0.0.0.0

--- a/devops/docker/docker-compose.yml
+++ b/devops/docker/docker-compose.yml
@@ -147,7 +147,7 @@ services:
       start_period: 30s
 
   bifrost:
-    image: maximhq/bifrost:v1.6.7
+    image: ghcr.io/maximhq/bifrost:v1.6.7
     restart: unless-stopped
     environment:
       APP_HOST: 0.0.0.0


### PR DESCRIPTION
- Switch to pulling the bifrost image from `ghcr.io` instead of Docker Hub (`docker-compose.yml`, `docker-compose.local.yml`, and `.github/workflows/e2e.yml`)