### PR TITLE
TD-1467: Default Bifrost env vars for local dev via .env.development

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,9 +72,14 @@ jobs:
       # Disable telemetry
       NEXT_TELEMETRY_DISABLED: 1
       TURBO_TELEMETRY_DISABLED: 1
+      # Crawl4AI
       CRAWL4AI_API_TOKEN: ais-chat-crawl4ai-token
+      # Xberg
       XBERG_URL: http://localhost:8000
       XBERG_MAX_UPLOAD_SIZE_MB: '50'
+      # Bifrost
+      BIFROST_BASE_URL: http://localhost:8089/openai/v1
+      BIFROST_API_KEY: sk-bf-example-key
 
     steps:
       - name: Checkout code
@@ -115,7 +120,11 @@ jobs:
           docker run \
             --name bifrost \
             --network host \
+            -v "$PWD/devops/docker/bifrost/config.json:/app/data/config.json:ro" \
             -e APP_PORT=8089 \
+            -e BIFROST_ADMIN_USERNAME=admin \
+            -e BIFROST_ADMIN_PASSWORD=admin \
+            -e BIFROST_API_KEY=sk-bf-example-key \
             ghcr.io/maximhq/bifrost:v1.6.7 > /tmp/bifrost.log 2>&1 &
 
       - name: Setup pnpm
@@ -161,23 +170,11 @@ jobs:
           done
         env:
           PORT: 3002
-          BIFROST_BASE_URL: http://localhost:8089/openai/v1
 
       - name: Seed ais-chat-api database
         # db:seed will print the generated API KEY on the console
         # The output is captured in GITHUB_ENV for seeding ais-chat-app
         run: |
-          timeout=60
-          elapsed=0
-          until wget -qO- http://localhost:8089/api/providers > /dev/null 2>&1; do
-            if [ $elapsed -ge $timeout ]; then
-              echo "Bifrost did not become ready within ${timeout}s"
-              exit 1
-            fi
-            echo "$(date) - waiting for Bifrost to be ready"
-            sleep 1
-            elapsed=$((elapsed + 1))
-          done
           pnpm --filter @ais-chat/api-database db:seed | tee /tmp/out.txt
           grep -E '^DE_[A-Z0-9_]*_API_KEY=' /tmp/out.txt >> "$GITHUB_ENV"
         env:
@@ -219,7 +216,6 @@ jobs:
         env:
           NODE_ENV: test
           LINKUP_API_KEY: ${{ secrets.LINKUP_API_KEY }}
-          BIFROST_BASE_URL: http://localhost:8089/openai/v1
 
       - name: Run E2E tests (app)
         run: pnpm --filter ais-chat-app e2e

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
-!.env
-!.env.e2e
+!.env.development
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ The project uses environment variables in `.env.local` files for local developme
 
 For detailed variable documentation and values for local development with docker-compose, see the `.env.example` files in each app directory.
 
+**How env files are loaded:**
+
+- Precedence (highest to lowest): `.env.local` > `.env.development`. `.env.development` holds working defaults for local dev, so `.env.local` doesn't need to set them.
+- `apps/chat-bot`/`apps/admin` get this (plus a lower-priority `.env` tier) via Next.js's built-in env loading.
+- `apps/api` (Fastify) has no built-in loading, so `apps/api/src/load-env.ts` replicates the `.env.local` > `.env.development` precedence manually (no `.env` tier, since no app ships one).
+
 ### Service dependencies
 
 For local development spin up all required services using docker compose:

--- a/apps/admin/.env.development
+++ b/apps/admin/.env.development
@@ -1,0 +1,4 @@
+# Bifrost gateway management API
+BIFROST_ADMIN_URL=http://localhost:8089
+BIFROST_ADMIN_USERNAME=admin
+BIFROST_ADMIN_PASSWORD=admin

--- a/apps/admin/src/consts/env.ts
+++ b/apps/admin/src/consts/env.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 export const env = createEnv({
   emptyStringAsUndefined: true,
   server: {
-    bifrostAdminUrl: z.string().url().optional(),
+    bifrostAdminUrl: z.url().optional(),
     bifrostAdminUsername: z.string().optional(),
     bifrostAdminPassword: z.string().optional(),
     databaseUrl: z.string(),

--- a/apps/api/.env.development
+++ b/apps/api/.env.development
@@ -1,0 +1,3 @@
+# Bifrost gateway inference API
+BIFROST_BASE_URL=http://localhost:8089/openai/v1
+BIFROST_API_KEY=sk-bf-example-key

--- a/apps/api/src/load-env.ts
+++ b/apps/api/src/load-env.ts
@@ -5,7 +5,16 @@ import path from 'node:path';
 // This must be imported before any other module that reads process.env.
 // In production, environment variables are provided by the runtime (e.g. Docker).
 if (process.env.NODE_ENV !== 'production') {
-  config({ path: path.resolve(import.meta.dirname, '..', '.env.local') });
+  // Load defaults for the current NODE_ENV first (e.g. .env.development), then
+  // .env.local with override so it takes precedence, mirroring Next.js's own
+  // .env.local > .env.$(NODE_ENV) precedence. Defaults to 'development' when
+  // NODE_ENV is unset to avoid trying to load a nonsensical ".env.undefined".
+  const nodeEnv = process.env.NODE_ENV ?? 'development';
+  config({ path: path.resolve(import.meta.dirname, '..', `.env.${nodeEnv}`) });
+  config({
+    path: path.resolve(import.meta.dirname, '..', '.env.local'),
+    override: true,
+  });
 }
 
 // Default API_DATABASE_URL to DATABASE_URL so operators only need to configure

--- a/apps/chat-bot/.env.development
+++ b/apps/chat-bot/.env.development
@@ -1,0 +1,3 @@
+# Bifrost gateway inference API
+BIFROST_BASE_URL=http://localhost:8089/openai/v1
+BIFROST_API_KEY=sk-bf-example-key

--- a/packages/ai-core/src/env.ts
+++ b/packages/ai-core/src/env.ts
@@ -10,7 +10,7 @@ export const env = createEnv({
     // TODO: @AsamMax - "optional" is highly temporary, just to skip some e2e errors
     apiDatabaseUrl: z.string().optional(),
     bifrostApiKey: z.string().optional(),
-    bifrostBaseUrl: z.string().url().optional(),
+    bifrostBaseUrl: z.url().optional(),
   },
   runtimeEnv: {
     apiDatabaseUrl: process.env.API_DATABASE_URL,


### PR DESCRIPTION
- Adds a committed `.env.development` in `apps/admin` and `apps/chat-bot` with working Bifrost gateway defaults for local development, so `.env.local` no longer needs to set them manually. Next.js loads these files automatically, with `.env.local` overriding any value present in both.
- `apps/api` (Fastify) has no built-in env file loading, so `load-env.ts` now replicates the same precedence manually: it loads `.env.${NODE_ENV}` first, then `.env.local` with `override: true` so it always wins.
- Also switches the deprecated `z.string().url()` to `z.url()` in `apps/admin`/`packages/ai-core` env schemas.
- Configures the e2e workflow's Bifrost container with admin credentials and an API key (previously ran with no auth configured), and moves the common Bifrost env vars to the job-level `env:` section with a header, matching the existing Crawl4AI/Xberg/S3 sections.

Jira: TD-1467