### PR TITLE
chore: bump xberg image to 1.0.8-core

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,7 +108,7 @@ jobs:
             --name xberg \
             -p 8000:8000 \
             -e XBERG_MAX_UPLOAD_SIZE_MB=$XBERG_MAX_UPLOAD_SIZE_MB \
-            ghcr.io/xberg-io/xberg:1.0.0-rc.29-core > /tmp/xberg.log 2>&1 &
+            ghcr.io/xberg-io/xberg:1.0.8-core > /tmp/xberg.log 2>&1 &
 
       - name: Start bifrost container (in background)
         run: |

--- a/devops/docker/docker-compose.local.yml
+++ b/devops/docker/docker-compose.local.yml
@@ -98,7 +98,7 @@ services:
       start_period: 40s
 
   xberg:
-    image: ghcr.io/xberg-io/xberg:1.0.0-rc.29-core
+    image: ghcr.io/xberg-io/xberg:1.0.8-core
     environment:
       XBERG_MAX_UPLOAD_SIZE_MB: '50'
     ports:

--- a/devops/docker/docker-compose.yml
+++ b/devops/docker/docker-compose.yml
@@ -108,7 +108,7 @@ services:
 
   # Xberg text extraction service
   xberg:
-    image: ghcr.io/xberg-io/xberg:1.0.0-rc.29-core
+    image: ghcr.io/xberg-io/xberg:1.0.8-core
     restart: unless-stopped
     environment:
       XBERG_MAX_UPLOAD_SIZE_MB: '50'


### PR DESCRIPTION
- Bump `ghcr.io/xberg-io/xberg` image from `1.0.0-rc.29-core` to `1.0.8-core`
- Updated in `docker-compose.yml`, `docker-compose.local.yml`, and the e2e workflow