### PR TITLE
TD-1279: Remove unused @x402/core and @x402/evm dependencies

### DIFF
--- a/apps/chat-bot/package.json
+++ b/apps/chat-bot/package.json
@@ -50,8 +50,6 @@
     "@t3-oss/env-nextjs": "0.13.11",
     "@tanstack/react-query": "5.101.4",
     "@tanstack/react-virtual": "3.14.9",
-    "@x402/core": "2.20.0",
-    "@x402/evm": "2.20.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "date-fns": "4.4.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -43,8 +43,6 @@
     "@sentry/nextjs": "10.69.0",
     "@sentry/opentelemetry": "10.69.0",
     "@t3-oss/env-core": "0.13.11",
-    "@x402/core": "2.20.0",
-    "@x402/evm": "2.20.0",
     "drizzle-kit": "0.31.10",
     "drizzle-orm": "0.45.2",
     "drizzle-zod": "0.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,12 +339,6 @@ importers:
       '@tanstack/react-virtual':
         specifier: 3.14.9
         version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@x402/core':
-        specifier: 2.20.0
-        version: 2.20.0
-      '@x402/evm':
-        specifier: 2.20.0
-        version: 2.20.0(typescript@6.0.3)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -775,12 +769,6 @@ importers:
       '@t3-oss/env-core':
         specifier: 0.13.11
         version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
-      '@x402/core':
-        specifier: 2.20.0
-        version: 2.20.0
-      '@x402/evm':
-        specifier: 2.20.0
-        version: 2.20.0(typescript@6.0.3)
       drizzle-kit:
         specifier: 0.31.10
         version: 0.31.10
@@ -15354,6 +15342,7 @@ snapshots:
       - bufferutil
       - typescript
       - utf-8-validate
+    optional: true
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -15363,6 +15352,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
       zod: 3.25.76
+    optional: true
 
   abitype@1.2.3(typescript@6.0.3)(zod@4.4.3):
     optionalDependencies:
@@ -15373,6 +15363,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
       zod: 3.25.76
+    optional: true
 
   abitype@1.3.0(typescript@6.0.3)(zod@4.4.3):
     optionalDependencies:
@@ -18516,6 +18507,7 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - zod
+    optional: true
 
   ox@0.14.33(typescript@6.0.3)(zod@4.4.3):
     dependencies:
@@ -20158,6 +20150,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
       - zod
+    optional: true
 
   viem@2.55.10(typescript@6.0.3)(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
- Removes unused `@x402/core` and `@x402/evm` dependencies from `apps/chat-bot` and `packages/shared`
- Updates `pnpm-lock.yaml` accordingly

Jira: TD-1279