### PR TITLE
TD-1462: stabilize flaky chat-completions e2e test

### DIFF
--- a/apps/api/e2e/tests/chat-completions.api.test.ts
+++ b/apps/api/e2e/tests/chat-completions.api.test.ts
@@ -62,12 +62,12 @@ test.describe('POST /v1/chat/completions', () => {
     test('returns a successful response when sending temperature to gpt-5-mini', async ({
       request,
     }) => {
-      const reasoningModel = await getModel(request, 'gpt-5-mini');
+      const gpt5MiniModel = await getModel(request, 'gpt-5-mini');
 
       const response = await request.post('/v1/chat/completions', {
         headers: authorizationHeader,
         data: {
-          model: reasoningModel.name,
+          model: gpt5MiniModel.name,
           messages: [{ role: 'user', content: 'Reply with exactly: hello' }],
           max_tokens: 200,
           temperature: 0.1,

--- a/apps/api/e2e/tests/chat-completions.api.test.ts
+++ b/apps/api/e2e/tests/chat-completions.api.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '@playwright/test';
-import { authorizationHeader, getReasoningModel, getTextModel } from '../utils/api.js';
+import { expect, test } from '@playwright/test';
+import { authorizationHeader, getModel, getTextModel } from '../utils/api.js';
 
 test.describe('POST /v1/chat/completions', () => {
   test.describe('Non-streaming', () => {
@@ -34,7 +34,7 @@ test.describe('POST /v1/chat/completions', () => {
         data: {
           model: textModel.name,
           messages: [{ role: 'user', content: 'Reply with exactly: hello' }],
-          max_tokens: 50,
+          max_tokens: 200,
           temperature: 0.1,
           stream: false,
         },
@@ -62,14 +62,14 @@ test.describe('POST /v1/chat/completions', () => {
     test('returns a successful response when sending temperature to gpt-5-mini', async ({
       request,
     }) => {
-      const reasoningModel = await getReasoningModel(request);
+      const reasoningModel = await getModel(request, 'gpt-5-mini');
 
       const response = await request.post('/v1/chat/completions', {
         headers: authorizationHeader,
         data: {
           model: reasoningModel.name,
           messages: [{ role: 'user', content: 'Reply with exactly: hello' }],
-          max_tokens: 50,
+          max_tokens: 200,
           temperature: 0.1,
           stream: false,
         },
@@ -95,7 +95,7 @@ test.describe('POST /v1/chat/completions', () => {
         data: {
           model: textModel.name,
           messages: [{ role: 'user', content: 'Reply with exactly: hello' }],
-          max_tokens: 50,
+          max_tokens: 200,
           temperature: 0.1,
           stream: true,
         },

--- a/apps/api/e2e/utils/api.ts
+++ b/apps/api/e2e/utils/api.ts
@@ -10,8 +10,6 @@ export const authorizationHeader = {
   Authorization: `Bearer ${API_KEY}`,
 };
 
-export const baseURL = `http://localhost:${process.env.PORT ?? '3002'}`;
-
 type ApiModel = {
   name: string;
   isDeleted?: boolean;
@@ -57,12 +55,12 @@ export async function getTextModel(request: APIRequestContext) {
   );
 }
 
-/** Returns a reasoning model. Throws if none available. */
-export async function getReasoningModel(request: APIRequestContext) {
+/** Finds a model by name. Throws if none available. */
+export async function getModel(request: APIRequestContext, name: string) {
   return findModel(
     request,
-    (m) => !m.isDeleted && m.name.includes('gpt-5'),
-    'No reasoning model available',
+    (m) => !m.isDeleted && m.name === name,
+    `No model available with name: ${name}`,
   );
 }
 


### PR DESCRIPTION
Stabilizes a flaky e2e test as part of TD-1462:
- Raise `max_tokens` from 50 → 200 in chat-completions API e2e test to avoid truncated/empty completions causing flaky failures.
- Replace loose `getReasoningModel` (matched any model containing `gpt-5`) with a `getModel` helper that matches an exact model name, and use it to target `gpt-5-mini` explicitly.
- Remove unused `baseURL` export from `apps/api/e2e/utils/api.ts`.