### PR TITLE
TD-1462: detect empty AI responses in agentic loop, not providers

### DIFF
--- a/apps/api/e2e/tests/chat-completions.api.test.ts
+++ b/apps/api/e2e/tests/chat-completions.api.test.ts
@@ -84,6 +84,23 @@ test.describe('POST /v1/chat/completions', () => {
       expect(body.choices[0]).toHaveProperty('message');
       expect(body.choices[0].message).toHaveProperty('content');
     });
+
+    test('returns a successful empty response for max_tokens: 0', async ({ request }) => {
+      const textModel = await getTextModel(request);
+
+      const response = await request.post('/v1/chat/completions', {
+        headers: authorizationHeader,
+        data: {
+          model: textModel.name,
+          messages: [{ role: 'user', content: 'Reply with exactly: hello' }],
+          max_tokens: 0,
+          temperature: 0.1,
+          stream: false,
+        },
+      });
+
+      expect(response.status()).toBe(200);
+    });
   });
 
   test.describe('Streaming', () => {
@@ -134,6 +151,27 @@ test.describe('POST /v1/chat/completions', () => {
             chunk.choices?.[0]?.delta?.content,
         );
       expect(contentChunks.length).toBeGreaterThan(0);
+    });
+
+    test('returns a successful empty stream for max_tokens: 0', async ({ request }) => {
+      const textModel = await getTextModel(request);
+
+      const response = await request.post('/v1/chat/completions', {
+        headers: authorizationHeader,
+        data: {
+          model: textModel.name,
+          messages: [{ role: 'user', content: 'Reply with exactly: hello' }],
+          max_tokens: 0,
+          temperature: 0.1,
+          stream: true,
+        },
+      });
+
+      expect(response.status()).toBe(200);
+
+      const responseBody = await response.text();
+
+      expect(responseBody).toContain('[DONE]');
     });
   });
 });

--- a/apps/chat-bot/src/error/get-error-message-by-type.test.ts
+++ b/apps/chat-bot/src/error/get-error-message-by-type.test.ts
@@ -13,15 +13,9 @@ describe('getErrorMessageByType', () => {
   it('returns key for mapped ai-core errors', () => {
     expect(getErrorMessageByType(new TokenPointsExceededError())).toBe('rate-limit-error');
     expect(getErrorMessageByType(new SharedChatExpiredError())).toBe('chat-expired-error');
-    expect(
-      getErrorMessageByType(
-        new EmptyResponseError({
-          providerName: 'p',
-          modelName: 'm',
-          hasContent: false,
-        }),
-      ),
-    ).toBe('empty-response-error');
+    expect(getErrorMessageByType(new EmptyResponseError({ modelId: 'm' }))).toBe(
+      'empty-response-error',
+    );
   });
 
   it('returns not-found key for NotFoundError', () => {

--- a/packages/ai-core/src/chat/agent-loop.test.ts
+++ b/packages/ai-core/src/chat/agent-loop.test.ts
@@ -97,6 +97,34 @@ describe('agent-loop', () => {
     );
   });
 
+  it('calls onError with EmptyResponseError when the model produces no text', async () => {
+    const messages: Message[] = [{ role: 'user', content: 'Test query' }];
+    const onTextChunk = vi.fn();
+    const onComplete = vi.fn();
+    const onError = vi.fn();
+
+    mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+      yield { type: 'finish', usage } satisfies StreamEvent;
+    });
+
+    runAgentLoop({
+      modelSelection: { modelIds: ['test-model'], modelName: 'Test Model' },
+      apiKeyId: 'test-key',
+      messages,
+      agentName: 'Test Agent',
+      onTextChunk,
+      onComplete,
+      onError,
+    });
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalled();
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ name: 'EmptyResponseError' }));
+  });
+
   it('does not insert separator on first iteration', async () => {
     const messages: Message[] = [{ role: 'user', content: 'Test query' }];
     const onTextChunk = vi.fn();
@@ -456,6 +484,7 @@ describe('agent-loop', () => {
       const onError = vi.fn();
 
       mockGenerateAgenticStreamWithBilling.mockImplementation(async function* () {
+        yield { type: 'text', delta: 'Using tool.' } satisfies StreamEvent;
         yield {
           type: 'tool_call',
           call: { id: 'call_1', name: 'test_tool', arguments: '{}' },

--- a/packages/ai-core/src/chat/agent-loop.ts
+++ b/packages/ai-core/src/chat/agent-loop.ts
@@ -6,6 +6,7 @@ import type {
   ToolCall,
   ToolRegistry,
 } from './types';
+import { EmptyResponseError } from '../errors';
 
 export const MAX_AGENTIC_ITERATIONS = 3;
 export const MAX_TOOL_CALLS_PER_ITERATION = 2;
@@ -178,6 +179,11 @@ export function runAgentLoop({
           agentSpan.setAttribute('gen_ai.usage.total_tokens', totalUsage.totalTokens);
         },
       );
+
+      if (fullText.trim().length === 0) {
+        onError(new EmptyResponseError({ modelId: lastModelId }));
+        return;
+      }
 
       onComplete({
         fullText,

--- a/packages/ai-core/src/chat/agentic-stream.ts
+++ b/packages/ai-core/src/chat/agentic-stream.ts
@@ -12,7 +12,7 @@ import type { TokenUsage, GenerationOptions, StreamEvent, Message, ModelSelectio
  * This function first verifies that the provided API key has access to the requested text model.
  * Note: Billing happens after the stream completes when usage data is available.
  *
- * @param modelId - The ID of the text model to use for generation
+ * @param selection - The model selection (candidate model IDs, display name, and usage callback) to use for generation
  * @param messages - The conversation messages (system, user, assistant)
  * @param apiKeyId - The ID of the API key to verify access and bill usage
  * @param onComplete - Called after the stream finishes with usage and cost

--- a/packages/ai-core/src/chat/providers/azure.test.ts
+++ b/packages/ai-core/src/chat/providers/azure.test.ts
@@ -60,64 +60,67 @@ describe('Azure Responses chat providers', () => {
     vi.clearAllMocks();
   });
 
-  it('streams Azure Responses output and maps usage without forwarding temperature', async () => {
-    responsesCreateMock.mockResolvedValue({
-      [Symbol.asyncIterator]: async function* () {
-        yield { type: 'response.output_text.delta', delta: 'Hello' };
-        yield { type: 'response.output_text.delta', delta: ' world' };
-        yield {
-          type: 'response.completed',
-          response: {
-            usage: {
-              input_tokens: 10,
-              output_tokens: 20,
-              total_tokens: 30,
+  it.each(['response.completed', 'response.incomplete', 'response.failed'] as const)(
+    'streams Azure Responses output and captures usage from a %s event',
+    async (eventType) => {
+      responsesCreateMock.mockResolvedValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: 'response.output_text.delta', delta: 'Hello' };
+          yield { type: 'response.output_text.delta', delta: ' world' };
+          yield {
+            type: eventType,
+            response: {
+              usage: {
+                input_tokens: 10,
+                output_tokens: 20,
+                total_tokens: 30,
+              },
             },
-          },
-        };
-      },
-    });
+          };
+        },
+      });
 
-    const model = createAzureModel({
-      reasoning: { effort: 'low' },
-    });
-    const streamText = constructAzureResponsesStreamFn(model);
-    const onComplete = vi.fn();
-    const chunks: string[] = [];
-
-    for await (const chunk of streamText(
-      {
-        messages: [{ role: 'user', content: 'Hello there' }],
-        model: model.name,
-        maxTokens: 128,
-      },
-      onComplete,
-    )) {
-      chunks.push(chunk);
-    }
-
-    expect(chunks).toEqual(['Hello', ' world']);
-    expect(responsesCreateMock).toHaveBeenCalledTimes(1);
-    expect(responsesCreateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'chat-deploy',
-        stream: true,
-        max_output_tokens: 128,
+      const model = createAzureModel({
         reasoning: { effort: 'low' },
-      }),
-      {
-        path: '/openai/responses',
-      },
-    );
+      });
+      const streamText = constructAzureResponsesStreamFn(model);
+      const onComplete = vi.fn();
+      const chunks: string[] = [];
 
-    const requestPayload = responsesCreateMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(requestPayload).not.toHaveProperty('temperature');
-    expect(onComplete).toHaveBeenCalledWith({
-      promptTokens: 10,
-      completionTokens: 20,
-      totalTokens: 30,
-    });
-  });
+      for await (const chunk of streamText(
+        {
+          messages: [{ role: 'user', content: 'Hello there' }],
+          model: model.name,
+          maxTokens: 128,
+        },
+        onComplete,
+      )) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual(['Hello', ' world']);
+      expect(responsesCreateMock).toHaveBeenCalledTimes(1);
+      expect(responsesCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'chat-deploy',
+          stream: true,
+          max_output_tokens: 128,
+          reasoning: { effort: 'low' },
+        }),
+        {
+          path: '/openai/responses',
+        },
+      );
+
+      const requestPayload = responsesCreateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(requestPayload).not.toHaveProperty('temperature');
+      expect(onComplete).toHaveBeenCalledWith({
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+      });
+    },
+  );
 
   it('generates Azure Responses text and usage without forwarding temperature', async () => {
     responsesCreateMock.mockResolvedValue({

--- a/packages/ai-core/src/chat/providers/azure.ts
+++ b/packages/ai-core/src/chat/providers/azure.ts
@@ -7,7 +7,7 @@ import type {
   TextStreamFn,
   TokenUsage,
 } from '../types';
-import { EmptyResponseError, ProviderConfigurationError } from '../../errors';
+import { AiGenerationError, ProviderConfigurationError } from '../../errors';
 import { toOpenAIResponsesInput } from '../utils';
 import { streamOpenAICompatibleAgenticResponse } from './openai-compatible';
 
@@ -55,16 +55,19 @@ export function constructAzureResponsesStreamFn(model: AiModel): TextStreamFn {
       },
     );
 
-    let hasContent = false;
     let usage: TokenUsage | undefined;
 
     for await (const event of response) {
       if (event.type === 'response.output_text.delta') {
-        hasContent = true;
         yield event.delta;
       }
 
-      if (event.type === 'response.completed' && event.response.usage) {
+      if (
+        (event.type === 'response.completed' ||
+          event.type === 'response.incomplete' ||
+          event.type === 'response.failed') &&
+        event.response.usage
+      ) {
         usage = {
           completionTokens: event.response.usage.output_tokens,
           promptTokens: event.response.usage.input_tokens,
@@ -73,12 +76,8 @@ export function constructAzureResponsesStreamFn(model: AiModel): TextStreamFn {
       }
     }
 
-    if (!usage || !hasContent) {
-      throw new EmptyResponseError({
-        providerName: 'Azure OpenAI',
-        modelName: deployment,
-        hasContent,
-      });
+    if (!usage) {
+      throw new AiGenerationError('No usage data returned from Azure OpenAI Responses API stream');
     }
 
     if (onComplete) {
@@ -139,12 +138,8 @@ export function constructAzureResponsesGenerationFn(model: AiModel): TextGenerat
 
     const usage = response.usage;
 
-    if (!usage || text.trim().length === 0) {
-      throw new EmptyResponseError({
-        providerName: 'Azure OpenAI',
-        modelName: deployment,
-        hasContent: text.trim().length > 0,
-      });
+    if (!usage) {
+      throw new AiGenerationError('No usage data returned from Azure OpenAI Responses API');
     }
 
     return {

--- a/packages/ai-core/src/chat/providers/bifrost.test.ts
+++ b/packages/ai-core/src/chat/providers/bifrost.test.ts
@@ -154,38 +154,41 @@ describe('Bifrost chat provider', () => {
     );
   });
 
-  it('streams text and maps usage', async () => {
-    responsesCreateMock.mockResolvedValue({
-      [Symbol.asyncIterator]: async function* () {
-        yield { type: 'response.output_text.delta', delta: 'Hello' };
-        yield { type: 'response.output_text.delta', delta: ' world' };
-        yield {
-          type: 'response.completed',
-          response: { usage: { input_tokens: 4, output_tokens: 5, total_tokens: 9 } },
-        };
-      },
-    });
+  it.each(['response.completed', 'response.incomplete', 'response.failed'] as const)(
+    'streams text and captures usage from a %s event',
+    async (eventType) => {
+      responsesCreateMock.mockResolvedValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: 'response.output_text.delta', delta: 'Hello' };
+          yield { type: 'response.output_text.delta', delta: ' world' };
+          yield {
+            type: eventType,
+            response: { usage: { input_tokens: 4, output_tokens: 5, total_tokens: 9 } },
+          };
+        },
+      });
 
-    const model = createBifrostModel('ionos');
-    const streamText = constructBifrostTextStreamFn(model);
-    const onComplete = vi.fn();
-    const chunks: string[] = [];
+      const model = createBifrostModel('ionos');
+      const streamText = constructBifrostTextStreamFn(model);
+      const onComplete = vi.fn();
+      const chunks: string[] = [];
 
-    for await (const chunk of streamText(
-      { messages: [{ role: 'user', content: 'Hello' }], model: model.name },
-      onComplete,
-    )) {
-      chunks.push(chunk);
-    }
+      for await (const chunk of streamText(
+        { messages: [{ role: 'user', content: 'Hello' }], model: model.name },
+        onComplete,
+      )) {
+        chunks.push(chunk);
+      }
 
-    expect(chunks).toEqual(['Hello', ' world']);
-    expect(responsesCreateMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5' }));
-    expect(onComplete).toHaveBeenCalledWith({
-      promptTokens: 4,
-      completionTokens: 5,
-      totalTokens: 9,
-    });
-  });
+      expect(chunks).toEqual(['Hello', ' world']);
+      expect(responsesCreateMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5' }));
+      expect(onComplete).toHaveBeenCalledWith({
+        promptTokens: 4,
+        completionTokens: 5,
+        totalTokens: 9,
+      });
+    },
+  );
 
   it('uses the actual deployment when identifying a fallback response', async () => {
     responsesCreateMock.mockResolvedValue({

--- a/packages/ai-core/src/chat/providers/bifrost.ts
+++ b/packages/ai-core/src/chat/providers/bifrost.ts
@@ -7,7 +7,7 @@ import type {
   TextStreamFn,
   TokenUsage,
 } from '../types';
-import { EmptyResponseError, ProviderConfigurationError } from '../../errors';
+import { AiGenerationError, ProviderConfigurationError } from '../../errors';
 import { toOpenAIResponsesInput } from '../utils';
 import { streamOpenAICompatibleAgenticResponse } from './openai-compatible';
 import { env } from '../../env';
@@ -87,17 +87,20 @@ export function constructBifrostTextStreamFn(model: AiModel): TextStreamFn {
       ...(fallbackModels?.length ? { fallbacks: fallbackModels.map(getBifrostModelName) } : {}),
     });
 
-    let hasContent = false;
     let usage: TokenUsage | undefined;
     let modelId: string | undefined;
 
     for await (const event of response) {
       if (event.type === 'response.output_text.delta') {
-        hasContent = true;
         yield event.delta;
       }
 
-      if (event.type === 'response.completed' && event.response.usage) {
+      if (
+        (event.type === 'response.completed' ||
+          event.type === 'response.incomplete' ||
+          event.type === 'response.failed') &&
+        event.response.usage
+      ) {
         usage = {
           completionTokens: event.response.usage.output_tokens,
           promptTokens: event.response.usage.input_tokens,
@@ -110,12 +113,8 @@ export function constructBifrostTextStreamFn(model: AiModel): TextStreamFn {
       }
     }
 
-    if (!usage || !hasContent) {
-      throw new EmptyResponseError({
-        providerName: 'Bifrost',
-        modelName,
-        hasContent,
-      });
+    if (!usage) {
+      throw new AiGenerationError('No usage data returned from Bifrost stream');
     }
 
     if (onComplete) {
@@ -179,12 +178,8 @@ export function constructBifrostTextGenerationFn(model: AiModel): TextGeneration
 
     const usage = response.usage;
 
-    if (!usage || text.trim().length === 0) {
-      throw new EmptyResponseError({
-        providerName: 'Bifrost',
-        modelName,
-        hasContent: text.trim().length > 0,
-      });
+    if (!usage) {
+      throw new AiGenerationError('No usage data returned from Bifrost');
     }
 
     return {

--- a/packages/ai-core/src/chat/providers/openai-compatible.test.ts
+++ b/packages/ai-core/src/chat/providers/openai-compatible.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import type OpenAI from 'openai';
+import { streamOpenAICompatibleAgenticResponse } from './openai-compatible';
+import { AiGenerationError } from '../../errors';
+
+function createClient(events: unknown[]): OpenAI {
+  return {
+    responses: {
+      create: vi.fn().mockResolvedValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield* events;
+        },
+      }),
+    },
+  } as unknown as OpenAI;
+}
+
+describe('streamOpenAICompatibleAgenticResponse', () => {
+  it.each(['response.completed', 'response.incomplete', 'response.failed'] as const)(
+    'captures usage from a %s event',
+    async (eventType) => {
+      const client = createClient([
+        { type: 'response.output_text.delta', delta: 'Hello' },
+        {
+          type: eventType,
+          response: { usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 } },
+        },
+      ]);
+
+      const events = [];
+      for await (const event of streamOpenAICompatibleAgenticResponse({
+        client,
+        messages: [{ role: 'user', content: 'Hi' }],
+        modelName: 'test-model',
+        providerName: 'Test',
+      })) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([
+        { type: 'text', delta: 'Hello' },
+        { type: 'finish', usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 } },
+      ]);
+    },
+  );
+
+  it('still throws when no usage is ever returned', async () => {
+    const client = createClient([{ type: 'response.output_text.delta', delta: 'Hello' }]);
+
+    const generator = streamOpenAICompatibleAgenticResponse({
+      client,
+      messages: [{ role: 'user', content: 'Hi' }],
+      modelName: 'test-model',
+      providerName: 'Test',
+    });
+
+    const drain = async () => {
+      let result = await generator.next();
+      while (!result.done) {
+        result = await generator.next();
+      }
+    };
+
+    await expect(drain()).rejects.toThrow(AiGenerationError);
+  });
+});

--- a/packages/ai-core/src/chat/providers/openai-compatible.ts
+++ b/packages/ai-core/src/chat/providers/openai-compatible.ts
@@ -96,7 +96,12 @@ export async function* streamOpenAICompatibleAgenticResponse({
       existingToolCall.name = chunk.item.name;
       existingToolCall.arguments = chunk.item.arguments;
       toolCalls.set(chunk.output_index, existingToolCall);
-    } else if (chunk.type === 'response.completed' && chunk.response.usage) {
+    } else if (
+      (chunk.type === 'response.completed' ||
+        chunk.type === 'response.incomplete' ||
+        chunk.type === 'response.failed') &&
+      chunk.response.usage
+    ) {
       usage = {
         completionTokens: chunk.response.usage.output_tokens,
         promptTokens: chunk.response.usage.input_tokens,

--- a/packages/ai-core/src/chat/providers/openai.ts
+++ b/packages/ai-core/src/chat/providers/openai.ts
@@ -7,7 +7,7 @@ import type {
   TextStreamFn,
   TokenUsage,
 } from '../types';
-import { EmptyResponseError, ProviderConfigurationError } from '../../errors';
+import { AiGenerationError, ProviderConfigurationError } from '../../errors';
 import { toOpenAIMessages } from '../utils';
 import { streamOpenAICompatibleAgenticResponse } from './openai-compatible';
 
@@ -40,14 +40,12 @@ export function constructOpenAITextStreamFn(model: AiModel): TextStreamFn {
       temperature,
     });
 
-    let hasContent = false;
     let usage: TokenUsage | undefined;
 
     for await (const chunk of stream) {
       const chunkContent = chunk.choices[0]?.delta?.content;
 
       if (chunkContent) {
-        hasContent = true;
         yield chunkContent;
       }
 
@@ -60,12 +58,8 @@ export function constructOpenAITextStreamFn(model: AiModel): TextStreamFn {
       }
     }
 
-    if (!usage || !hasContent) {
-      throw new EmptyResponseError({
-        providerName: 'OpenAI',
-        modelName,
-        hasContent,
-      });
+    if (!usage) {
+      throw new AiGenerationError('No usage data returned from OpenAI stream');
     }
 
     if (onComplete) {
@@ -94,12 +88,8 @@ export function constructOpenAITextGenerationFn(model: AiModel): TextGenerationF
     const text = response.choices[0]?.message?.content ?? '';
     const usage = response.usage;
 
-    if (!usage || text.trim().length === 0) {
-      throw new EmptyResponseError({
-        providerName: 'OpenAI',
-        modelName,
-        hasContent: text.trim().length > 0,
-      });
+    if (!usage) {
+      throw new AiGenerationError('No usage data returned from OpenAI');
     }
 
     return {

--- a/packages/ai-core/src/errors.test.ts
+++ b/packages/ai-core/src/errors.test.ts
@@ -133,24 +133,14 @@ describe('SharedChatExpiredError', () => {
 
 describe('EmptyResponseError', () => {
   it('should create an error with neutral default message and correct name', () => {
-    const error = new EmptyResponseError({
-      providerName: 'provider',
-      modelName: 'model',
-      hasContent: false,
-    });
+    const error = new EmptyResponseError({ modelId: 'model' });
     expect(error.name).toBe('EmptyResponseError');
-    expect(error.message).toBe(
-      'Empty response from provider (providerName=provider, modelName=model, hasContent=false)',
-    );
+    expect(error.message).toBe('Empty response from provider (modelId=model)');
     expect(error).toBeInstanceOf(AiGenerationError);
   });
 
   it('should correctly identify EmptyResponseError instances', () => {
-    const error = new EmptyResponseError({
-      providerName: 'p',
-      modelName: 'm',
-      hasContent: false,
-    });
+    const error = new EmptyResponseError({ modelId: 'm' });
     expect(EmptyResponseError.is(error)).toBe(true);
     expect(EmptyResponseError.is(new AiGenerationError('Test'))).toBe(false);
   });
@@ -165,15 +155,7 @@ describe('isKnownAiGenerationError', () => {
     expect(isKnownAiGenerationError(new ProviderConfigurationError('Test'))).toBe(true);
     expect(isKnownAiGenerationError(new TokenPointsExceededError('Test'))).toBe(true);
     expect(isKnownAiGenerationError(new SharedChatExpiredError('Test'))).toBe(true);
-    expect(
-      isKnownAiGenerationError(
-        new EmptyResponseError({
-          providerName: 'p',
-          modelName: 'm',
-          hasContent: false,
-        }),
-      ),
-    ).toBe(true);
+    expect(isKnownAiGenerationError(new EmptyResponseError({ modelId: 'm' }))).toBe(true);
   });
 
   it('should return false for unknown values', () => {

--- a/packages/ai-core/src/errors.ts
+++ b/packages/ai-core/src/errors.ts
@@ -21,19 +21,13 @@ export class AiGenerationError extends Error {
  */
 export class EmptyResponseError extends AiGenerationError {
   constructor({
-    providerName,
-    modelName,
-    hasContent,
+    modelId,
     message = 'Empty response from provider',
   }: {
-    providerName: string;
-    modelName: string;
-    hasContent: boolean;
+    modelId: string;
     message?: string;
   }) {
-    super(
-      `${message} (providerName=${providerName}, modelName=${modelName}, hasContent=${String(hasContent)})`,
-    );
+    super(`${message} (modelId=${modelId})`);
     this.name = 'EmptyResponseError';
   }
 


### PR DESCRIPTION
Providers are shared with ais-chat-api, so throwing on empty content there rejected legitimate empty completions (e.g. max_tokens: 0). Providers now only throw on missing usage; empty-response detection moved to the chat-bot's agentic loop, the only consumer that needs it.

Also fixes usage not being captured on `response.incomplete`/`response.failed` (e.g. truncated by max_output_tokens), which previously threw a generic AiGenerationError before the empty-response check could run.

Testing: added/updated unit tests in ai-core (providers, agent-loop, errors) and an e2e test in ais-chat-api covering `max_tokens: 0`.