### PR TITLE
TD-1469: Add Judge0 code execution tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ For local development spin up all required services using docker compose:
 docker compose -f devops/docker/docker-compose.local.yml up -d --build
 ```
 
+Code execution additionally requires the isolated Judge0 stack. It uses privileged sandbox workers,
+so run it only on a trusted development machine or dedicated production host/VM:
+
+```sh
+export JUDGE0_DB_PASSWORD='use-a-local-secret'
+export JUDGE0_TOKEN='use-a-different-random-secret-at-least-32-characters'
+docker compose -f devops/docker/judge0/docker-compose.yml up -d
+```
+
+Host-run API development uses `JUDGE0_URL=http://127.0.0.1:2358`. For the packaged Docker stack,
+start Judge0 first; the API reaches `judge0-server` over the named private network. See
+[`devops/docker/judge0/README.md`](devops/docker/judge0/README.md) for security and retention details.
+
 To remove all data and start from scratch, you can stop and remove the container and its volume.
 This will delete your database and keycloak configuration.
 

--- a/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/FederalStateDetailView.tsx
+++ b/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/FederalStateDetailView.tsx
@@ -64,6 +64,7 @@ function transformToFederalStateEditForm(federalState: FederalStateModel): Feder
       isSharedPageLocaleDetectionEnabled:
         federalState.featureToggles.isSharedPageLocaleDetectionEnabled ?? true,
       isAgenticChatEnabled: federalState.featureToggles.isAgenticChatEnabled ?? false,
+      isCodeExecutionEnabled: federalState.featureToggles.isCodeExecutionEnabled ?? false,
     },
     supportContacts: federalState.supportContacts?.map((s) => ({ value: s })) ?? [],
     designConfiguration: federalState.designConfiguration
@@ -272,6 +273,12 @@ export function FederalStateView(props: FederalStateViewProps) {
             name="featureToggles.isAgenticChatEnabled"
             label="Agentic Chat aktivieren"
             description="Erlaubt die Nutzung des neuen agentic loop im Chat."
+            control={control}
+          />
+          <FormFieldCheckbox
+            name="featureToggles.isCodeExecutionEnabled"
+            label="Codeausführung aktivieren"
+            description="Erlaubt dem Chat, Python-, JavaScript- und TypeScript-Code sicher auszuführen."
             control={control}
           />
           <FormField

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -5,6 +5,12 @@ API_DATABASE_URL=postgresql://admin:test1234@127.0.0.1:5432/api_db
 API_KEY=
 API_NAME=ais-chat
 
+# Code execution gateway (private Judge0 CE service)
+JUDGE0_URL=http://127.0.0.1:2358
+JUDGE0_TOKEN=
+JUDGE0_TIMEOUT_MS=10000
+JUDGE0_POLL_INTERVAL_MS=250
+
 # Logging
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=

--- a/apps/api/src/code-execution.test.ts
+++ b/apps/api/src/code-execution.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { codeExecutionRequestSchema } from './code-execution';
+
+vi.mock('@/env', () => ({
+  env: {
+    judge0Url: 'https://judge0.example.test/',
+    judge0Token: 'judge0-test-token-that-is-long-enough',
+    judge0TimeoutMs: 100,
+    judge0PollIntervalMs: 1,
+  },
+}));
+
+describe('code execution request', () => {
+  it('accepts only the supported language and source', () => {
+    expect(
+      codeExecutionRequestSchema.safeParse({ language: 'python', sourceCode: 'print(1)' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects options and unknown languages', () => {
+    expect(
+      codeExecutionRequestSchema.safeParse({ language: 'ruby', sourceCode: 'puts 1' }).success,
+    ).toBe(false);
+    expect(
+      codeExecutionRequestSchema.safeParse({ language: 'python', sourceCode: 'x', stdin: 'bad' })
+        .success,
+    ).toBe(false);
+  });
+
+  it('bounds source size', () => {
+    expect(
+      codeExecutionRequestSchema.safeParse({ language: 'python', sourceCode: 'x'.repeat(256_001) })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe('executeCode', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('submits with fixed safe limits, disabled network, mapped language, polls, and bounds results', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ token: 'token/1' }), { status: 201 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: { id: 2, description: 'Processing' } })),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: { id: 3, description: 'Accepted' },
+            stdout: 'o'.repeat(65_000),
+            stderr: null,
+            compile_output: 'compile',
+            message: null,
+            exit_code: 0,
+            time: null,
+            memory: null,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const { executeCode } = await import('./code-execution');
+    const result = await executeCode({ language: 'typescript', sourceCode: 'console.log(1)' });
+
+    expect(result.stdout).toHaveLength(64_000);
+    expect(result).toMatchObject({
+      status: 'Accepted',
+      stderr: '',
+      compileOutput: 'compile',
+      message: '',
+      exitCode: 0,
+    });
+    expect(fetchMock.mock.calls[0]).toEqual([
+      'https://judge0.example.test/submissions?base64_encoded=false&wait=false',
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+        body: JSON.stringify({
+          language_id: 74,
+          source_code: 'console.log(1)',
+          enable_network: false,
+          cpu_time_limit: 2,
+          wall_time_limit: 5,
+          memory_limit: 128_000,
+          max_processes_and_or_threads: 32,
+          max_file_size: 1_024,
+        }),
+      }),
+    ]);
+    expect(fetchMock.mock.calls[1]![0]).toBe(
+      'https://judge0.example.test/submissions/token%2F1?base64_encoded=false',
+    );
+    expect(fetchMock.mock.calls[3]).toEqual([
+      'https://judge0.example.test/submissions/token%2F1',
+      expect.objectContaining({ method: 'DELETE' }),
+    ]);
+  });
+
+  it('fails on malformed submission responses and Judge0 errors', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 201 }));
+    const { executeCode } = await import('./code-execution');
+    await expect(executeCode({ language: 'python', sourceCode: 'print(1)' })).rejects.toThrow(
+      'submission token',
+    );
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(new Response('bad', { status: 503 }));
+    await expect(executeCode({ language: 'python', sourceCode: 'print(1)' })).rejects.toThrow(
+      'Judge0 request failed',
+    );
+  });
+
+  it('times out when Judge0 never reaches a terminal status', async () => {
+    fetchMock
+      .mockImplementationOnce(() =>
+        Promise.resolve(new Response(JSON.stringify({ token: 'never', status: { id: 2 } }))),
+      )
+      .mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify({ status: { id: 2 } }))),
+      );
+    const { executeCode } = await import('./code-execution');
+    await expect(executeCode({ language: 'javascript', sourceCode: '1' })).rejects.toThrow(
+      'timed out',
+    );
+    expect(fetchMock.mock.calls.at(-1)).toEqual([
+      'https://judge0.example.test/submissions/never',
+      expect.objectContaining({ method: 'DELETE' }),
+    ]);
+  });
+});

--- a/apps/api/src/code-execution.ts
+++ b/apps/api/src/code-execution.ts
@@ -1,0 +1,144 @@
+import { env } from '@/env';
+import { z } from 'zod';
+
+export const codeExecutionRequestSchema = z
+  .object({
+    language: z.enum(['python', 'javascript', 'typescript']),
+    sourceCode: z.string().min(1).max(256_000),
+  })
+  .strict();
+
+export type CodeExecutionRequest = z.infer<typeof codeExecutionRequestSchema>;
+
+const LANGUAGE_IDS: Record<CodeExecutionRequest['language'], number> = {
+  python: 71,
+  javascript: 63,
+  typescript: 74,
+};
+
+const MAX_OUTPUT = 64_000;
+const MAX_CONCURRENT_EXECUTIONS = 4;
+let activeExecutions = 0;
+const LIMITS = {
+  cpu_time_limit: 2,
+  wall_time_limit: 5,
+  memory_limit: 128_000,
+  max_processes_and_or_threads: 32,
+  max_file_size: 1_024,
+} as const;
+
+type Judge0Submission = {
+  token?: string;
+  status?: { id?: number; description?: string } | string;
+  stdout?: string | null;
+  stderr?: string | null;
+  compile_output?: string | null;
+  message?: string | null;
+  exit_code?: number | null;
+  time?: string | null;
+  memory?: number | null;
+};
+
+export type CodeExecutionResult = {
+  status: string;
+  stdout: string;
+  stderr: string;
+  compileOutput: string;
+  message: string;
+  exitCode: number | null;
+  time: string | null;
+  memory: number | null;
+};
+
+const bounded = (value: string | null | undefined, max = MAX_OUTPUT) => (value ?? '').slice(0, max);
+
+async function judge0Request(url: string, init: RequestInit): Promise<Judge0Submission> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      'X-Auth-Token': env.judge0Token,
+      'X-Auth-User': env.judge0Token,
+      ...init.headers,
+    },
+    signal: AbortSignal.timeout(env.judge0TimeoutMs),
+  });
+  if (!response.ok) throw new Error('Judge0 request failed');
+  return (await response.json()) as Judge0Submission;
+}
+
+async function deleteSubmission(baseUrl: string, token: string): Promise<void> {
+  const response = await fetch(`${baseUrl}/submissions/${encodeURIComponent(token)}`, {
+    method: 'DELETE',
+    headers: {
+      'X-Auth-Token': env.judge0Token,
+      'X-Auth-User': env.judge0Token,
+    },
+    signal: AbortSignal.timeout(env.judge0TimeoutMs),
+  });
+  if (!response.ok) throw new Error('Judge0 submission cleanup failed');
+}
+
+export class CodeExecutionCapacityError extends Error {}
+
+export async function executeCode(input: CodeExecutionRequest): Promise<CodeExecutionResult> {
+  if (activeExecutions >= MAX_CONCURRENT_EXECUTIONS) {
+    throw new CodeExecutionCapacityError('Code execution capacity reached');
+  }
+  activeExecutions += 1;
+
+  const baseUrl = env.judge0Url.replace(/\/$/, '');
+  let token: string | undefined;
+  try {
+    const submitted = await judge0Request(
+      `${baseUrl}/submissions?base64_encoded=false&wait=false`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          language_id: LANGUAGE_IDS[input.language],
+          source_code: input.sourceCode,
+          enable_network: false,
+          ...LIMITS,
+        }),
+      },
+    );
+    if (!submitted.token) throw new Error('Judge0 did not return a submission token');
+    token = submitted.token;
+
+    const deadline = Date.now() + env.judge0TimeoutMs;
+    let result = submitted;
+    let completed = false;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, env.judge0PollIntervalMs));
+      result = await judge0Request(
+        `${baseUrl}/submissions/${encodeURIComponent(submitted.token)}?base64_encoded=false`,
+        { method: 'GET' },
+      );
+      const statusId = typeof result.status === 'object' ? result.status.id : undefined;
+      if (statusId !== undefined && statusId > 2) {
+        completed = true;
+        break;
+      }
+    }
+
+    if (!completed) throw new Error('Judge0 execution timed out');
+
+    const status = typeof result.status === 'string' ? result.status : result.status?.description;
+    return {
+      status: bounded(status, 100),
+      stdout: bounded(result.stdout),
+      stderr: bounded(result.stderr),
+      compileOutput: bounded(result.compile_output),
+      message: bounded(result.message),
+      exitCode: result.exit_code ?? null,
+      time: result.time ?? null,
+      memory: result.memory ?? null,
+    };
+  } finally {
+    try {
+      if (token) await deleteSubmission(baseUrl, token);
+    } finally {
+      activeExecutions -= 1;
+    }
+  }
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -31,6 +31,10 @@ export const env = createEnv({
     sentryEnvironment: z.string().optional(),
     sentryTracesSampleRate: z.coerce.number().default(1.0),
     sentryProfileSessionSampleRate: z.coerce.number().default(0.0),
+    judge0Url: z.string().url().default('http://127.0.0.1:2358'),
+    judge0Token: z.string().min(32),
+    judge0TimeoutMs: z.coerce.number().int().positive().max(30_000).default(10_000),
+    judge0PollIntervalMs: z.coerce.number().int().positive().max(5_000).default(250),
   },
   runtimeEnv: {
     appVersion: process.env.APP_VERSION,
@@ -46,5 +50,9 @@ export const env = createEnv({
     sentryEnvironment: process.env.SENTRY_ENVIRONMENT,
     sentryProfileSessionSampleRate: process.env.SENTRY_PROFILE_SESSION_SAMPLE_RATE,
     sentryTracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE,
+    judge0Url: process.env.JUDGE0_URL,
+    judge0Token: process.env.JUDGE0_TOKEN,
+    judge0TimeoutMs: process.env.JUDGE0_TIMEOUT_MS,
+    judge0PollIntervalMs: process.env.JUDGE0_POLL_INTERVAL_MS,
   },
 });

--- a/apps/api/src/handlers.ts
+++ b/apps/api/src/handlers.ts
@@ -10,6 +10,7 @@ import { modelRequestSwaggerSchema } from './routes/(app)/v1/models/swagger-sche
 import { usageRequestSwaggerSchema } from './routes/(app)/v1/usage/swagger-schemas';
 import { embeddingRequestSwaggerSchema } from './routes/(app)/v1/embeddings/swagger-schemas';
 import { imageGenerationRequestSwaggerSchema } from './routes/(app)/v1/images/generations/swagger-schemas';
+import { handler as v1_code_execute_postHandler } from './routes/(app)/v1/code/execute/post';
 
 export type RouteHandlerDefinition = Pick<RouteShorthandOptions, 'schema' | 'bodyLimit'> & {
   path: string;
@@ -30,6 +31,24 @@ export const healthSchema = {
 };
 
 export const routeHandlerDefinitions: Array<RouteHandlerDefinition> = [
+  {
+    path: '/v1/code/execute',
+    method: 'POST',
+    schema: {
+      security: [{ bearerAuth: [] }],
+      body: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['language', 'sourceCode'],
+        properties: {
+          language: { type: 'string', enum: ['python', 'javascript', 'typescript'] },
+          sourceCode: { type: 'string', maxLength: 256000 },
+        },
+      },
+    },
+    bodyLimit: 270_000,
+    handler: v1_code_execute_postHandler,
+  },
   {
     path: '/health',
     method: 'GET',

--- a/apps/api/src/routes/(app)/v1/code/execute/post.test.ts
+++ b/apps/api/src/routes/(app)/v1/code/execute/post.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  validateApiKey: vi.fn(),
+  executeCode: vi.fn(),
+}));
+
+vi.mock('@/routes/utils', () => ({ validateApiKey: mocks.validateApiKey }));
+vi.mock('@/code-execution', () => ({
+  CodeExecutionCapacityError: class CodeExecutionCapacityError extends Error {},
+  executeCode: mocks.executeCode,
+  codeExecutionRequestSchema: {
+    safeParse: (body: unknown) => {
+      if (!body || typeof body !== 'object' || !('language' in body) || !('sourceCode' in body))
+        return { success: false, error: { message: 'invalid' } };
+      return { success: true, data: body };
+    },
+  },
+}));
+
+const reply = () => {
+  const state = { statusCode: 200, body: undefined as unknown };
+  return {
+    state,
+    status(code: number) {
+      state.statusCode = code;
+      return this;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return this;
+    },
+  };
+};
+
+describe('POST /v1/code/execute handler', () => {
+  it('stops unauthenticated requests before validation or execution', async () => {
+    mocks.validateApiKey.mockResolvedValueOnce(undefined);
+    const { handler } = await import('./post');
+    const response = reply();
+    await handler({ body: {} } as never, response as never);
+    expect(response.state.statusCode).toBe(200);
+    expect(mocks.executeCode).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid input', async () => {
+    mocks.validateApiKey.mockResolvedValueOnce({ id: 'key-1' });
+    const { handler } = await import('./post');
+    const response = reply();
+    await handler({ body: { language: 'ruby' } } as never, response as never);
+    expect(response.state).toMatchObject({ statusCode: 400, body: { error: 'Bad request' } });
+  });
+
+  it('maps execution failures to 502', async () => {
+    mocks.validateApiKey.mockResolvedValueOnce({ id: 'key-1' });
+    mocks.executeCode.mockRejectedValueOnce(new Error('Judge0 down'));
+    const { handler } = await import('./post');
+    const response = reply();
+    await handler(
+      { body: { language: 'python', sourceCode: 'print(1)' } } as never,
+      response as never,
+    );
+    expect(response.state).toEqual({
+      statusCode: 502,
+      body: { error: 'Code execution service unavailable' },
+    });
+  });
+});

--- a/apps/api/src/routes/(app)/v1/code/execute/post.ts
+++ b/apps/api/src/routes/(app)/v1/code/execute/post.ts
@@ -1,0 +1,25 @@
+import {
+  CodeExecutionCapacityError,
+  executeCode,
+  codeExecutionRequestSchema,
+} from '@/code-execution';
+import { validateApiKey } from '@/routes/utils';
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+export async function handler(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if ((await validateApiKey(request, reply)) === undefined) return;
+  const parsed = codeExecutionRequestSchema.safeParse(request.body);
+  if (!parsed.success) {
+    reply.status(400).send({ error: 'Bad request', details: parsed.error.message });
+    return;
+  }
+  try {
+    reply.status(200).send(await executeCode(parsed.data));
+  } catch (error) {
+    if (error instanceof CodeExecutionCapacityError) {
+      reply.status(429).send({ error: 'Code execution capacity reached' });
+      return;
+    }
+    reply.status(502).send({ error: 'Code execution service unavailable' });
+  }
+}

--- a/apps/chat-bot/src/app/api/character/character-chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.test.ts
@@ -311,4 +311,27 @@ describe('sendCharacterMessage', () => {
       }),
     );
   });
+
+  it('uses the shared character owner federal-state code execution toggle', async () => {
+    mocks.getUserAndContextByUserIdMock.mockResolvedValue({
+      ...teacherUserAndContext,
+      federalState: {
+        ...teacherUserAndContext.federalState,
+        featureToggles: { isAgenticChatEnabled: true, isCodeExecutionEnabled: true },
+      },
+    });
+    mocks.buildToolsMock.mockResolvedValue({ toolRegistry: {} });
+
+    const { sendCharacterMessage } = await import('./character-chat-service');
+    await sendCharacterMessage({
+      characterId: character.id,
+      inviteCode: 'invite-code',
+      messages,
+      modelId: model.id,
+    });
+
+    expect(mocks.buildToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ allowCodeExecution: true }),
+    );
+  });
 });

--- a/apps/chat-bot/src/app/api/character/character-chat-service.ts
+++ b/apps/chat-bot/src/app/api/character/character-chat-service.ts
@@ -172,6 +172,9 @@ export async function sendCharacterMessage({
       sourceUrls: processedUrls,
       allowWebTools,
       allowMundoSearch: false,
+      allowCodeExecution:
+        agenticChatEnabled &&
+        (teacherUserAndContext.federalState.featureToggles.isCodeExecutionEnabled ?? false),
       onWebSearchResults: (results) => {
         update(
           encodeChatStreamEvent({

--- a/apps/chat-bot/src/app/api/chat/build-tools.test.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   buildRetrieveEntireFileToolMock: vi.fn(),
   buildRetrieveTextChunksToolMock: vi.fn(),
   buildMundoSearchToolMock: vi.fn(),
+  buildExecuteCodeToolMock: vi.fn(),
 }));
 
 vi.mock('./tools/web-search-tool', () => ({
@@ -28,6 +29,10 @@ vi.mock('./tools/retrieve-text-chunks-tool', () => ({
 
 vi.mock('./tools/mundo-search-tool', () => ({
   buildMundoSearchTool: mocks.buildMundoSearchToolMock,
+}));
+
+vi.mock('./tools/execute-code-tool', () => ({
+  buildExecuteCodeTool: mocks.buildExecuteCodeToolMock,
 }));
 
 const user = {
@@ -90,6 +95,15 @@ beforeEach(() => {
     definition: {
       name: 'mundo_search',
       description: 'Search MUNDO',
+      parameters: { type: 'object', properties: {} },
+    },
+    handler: vi.fn(),
+  });
+
+  mocks.buildExecuteCodeToolMock.mockReturnValue({
+    definition: {
+      name: 'execute_code',
+      description: 'Execute code',
       parameters: { type: 'object', properties: {} },
     },
     handler: vi.fn(),
@@ -194,5 +208,25 @@ describe('buildTools', () => {
 
     expect(Object.keys(toolRegistry)).toContain('mundo_search');
     expect(mocks.buildMundoSearchToolMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds execute_code only when code execution is allowed', async () => {
+    const { buildTools } = await import('./build-tools');
+
+    const disabled = await buildTools({
+      user,
+      relatedFileEntities,
+      allowWebTools: false,
+    });
+    const enabled = await buildTools({
+      user,
+      relatedFileEntities,
+      allowWebTools: false,
+      allowCodeExecution: true,
+    });
+
+    expect(disabled.toolRegistry).not.toHaveProperty('execute_code');
+    expect(enabled.toolRegistry).toHaveProperty('execute_code');
+    expect(mocks.buildExecuteCodeToolMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/chat-bot/src/app/api/chat/build-tools.ts
+++ b/apps/chat-bot/src/app/api/chat/build-tools.ts
@@ -6,6 +6,7 @@ import { buildWebScraperTool } from './tools/web-scraper-tool';
 import { buildRetrieveEntireFileTool } from './tools/retrieve-entire-file-tool';
 import { buildRetrieveTextChunksTool } from './tools/retrieve-text-chunks-tool';
 import { buildMundoSearchTool } from './tools/mundo-search-tool';
+import { buildExecuteCodeTool } from './tools/execute-code-tool';
 
 type BuildToolsParams = {
   user: UserAndContext;
@@ -18,6 +19,7 @@ type BuildToolsParams = {
   attachedLinks?: string[];
   allowWebTools: boolean;
   allowMundoSearch?: boolean;
+  allowCodeExecution?: boolean;
   onWebSearchResults?: (results: WebSearchResult[]) => void;
 };
 
@@ -36,6 +38,7 @@ export async function buildTools({
   attachedLinks = [],
   allowWebTools,
   allowMundoSearch,
+  allowCodeExecution = false,
   onWebSearchResults,
 }: BuildToolsParams): Promise<BuildToolsResult> {
   const toolRegistry: ToolRegistry = {};
@@ -69,6 +72,11 @@ export async function buildTools({
   if (allowMundoSearch) {
     const mundoSearchTool = buildMundoSearchTool();
     toolRegistry[mundoSearchTool.definition.name] = mundoSearchTool;
+  }
+
+  if (allowCodeExecution) {
+    const executeCodeTool = buildExecuteCodeTool();
+    if (executeCodeTool) toolRegistry[executeCodeTool.definition.name] = executeCodeTool;
   }
 
   const retrieveEntireFileTool = buildRetrieveEntireFileTool({

--- a/apps/chat-bot/src/app/api/chat/chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatMessage } from '@/types/chat';
 import type { UserAndContext } from '@/auth/types';
+import type { Message } from '@ais-chat/ai-core';
+import { filterPersistedAgentLoopMessages } from './chat-service';
 
 const webSearchResults = [
   {
@@ -349,6 +351,32 @@ beforeEach(() => {
   );
   mocks.generateAgenticStreamWithBillingMock.mockImplementation(async function* () {
     yield { type: 'text', delta: 'agentic chunk' };
+  });
+});
+
+describe('filterPersistedAgentLoopMessages', () => {
+  it('omits execute_code calls and their matching results while retaining other content', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          { id: 'code-call', name: 'execute_code', arguments: '{"sourceCode":"print(1)"}' },
+          { id: 'search-call', name: 'web_search', arguments: '{"query":"test"}' },
+        ],
+      },
+      { role: 'tool', content: '{"stdout":"1"}', toolCallId: 'code-call' },
+      { role: 'tool', content: 'search result', toolCallId: 'search-call' },
+    ];
+
+    expect(filterPersistedAgentLoopMessages(messages)).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [{ id: 'search-call', name: 'web_search', arguments: '{"query":"test"}' }],
+      },
+      { role: 'tool', content: 'search result', toolCallId: 'search-call' },
+    ]);
   });
 });
 

--- a/apps/chat-bot/src/app/api/chat/chat-service.ts
+++ b/apps/chat-bot/src/app/api/chat/chat-service.ts
@@ -66,13 +66,13 @@ type CustomChatIds = {
   assistantId?: string | undefined;
 };
 
-function filterPersistedAgentLoopMessages(agentLoopMessages: AiCoreMessage[]) {
+export function filterPersistedAgentLoopMessages(agentLoopMessages: AiCoreMessage[]) {
   const excludedToolCallIds = new Set<string>();
 
   return agentLoopMessages.flatMap((message) => {
     if (message.role === 'assistant' && message.toolCalls?.length) {
       const retainedToolCalls = message.toolCalls.filter((toolCall) => {
-        if (toolCall.name === 'retrieve_entire_file') {
+        if (toolCall.name === 'retrieve_entire_file' || toolCall.name === 'execute_code') {
           excludedToolCallIds.add(toolCall.id);
           return false;
         }
@@ -414,6 +414,9 @@ export async function sendChatMessage({
       sourceUrls: ingestResult.processedUrls,
       allowWebTools,
       allowMundoSearch: true,
+      allowCodeExecution:
+        (user.federalState.featureToggles.isAgenticChatEnabled ?? false) &&
+        (user.federalState.featureToggles.isCodeExecutionEnabled ?? false),
       onWebSearchResults: (results) => {
         update(
           encodeChatStreamEvent({

--- a/apps/chat-bot/src/app/api/chat/tools/execute-code-tool.test.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/execute-code-tool.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchMock = vi.fn();
+
+vi.mock('@/env', () => ({
+  env: { apiUrl: 'https://api.example.test/', apiKey: 'tool-secret' },
+}));
+
+describe('buildExecuteCodeTool', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('rejects unsupported, empty, oversized, and extra arguments without a request', async () => {
+    const { buildExecuteCodeTool } = await import('./execute-code-tool');
+    const tool = buildExecuteCodeTool()!;
+
+    for (const args of [
+      { language: 'ruby', sourceCode: 'puts 1' },
+      { language: 'python', sourceCode: '' },
+      { language: 'python', sourceCode: 'x'.repeat(256_001) },
+      { language: 'python', sourceCode: 'print(1)', stdin: 'secret' },
+    ]) {
+      expect(JSON.parse(await tool.handler(args))).toEqual({
+        error: 'Invalid execute_code arguments.',
+      });
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends language/source with the API bearer header and returns a valid result', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'Accepted',
+          stdout: '1',
+          stderr: '',
+          compileOutput: '',
+          message: '',
+          exitCode: 0,
+          time: '0.1',
+          memory: 100,
+        }),
+        { status: 200 },
+      ),
+    );
+    const { buildExecuteCodeTool } = await import('./execute-code-tool');
+    const result = JSON.parse(
+      await buildExecuteCodeTool()!.handler({
+        language: 'typescript',
+        sourceCode: 'console.log(1)',
+      }),
+    );
+
+    expect(result).toMatchObject({ status: 'Accepted', stdout: '1', exitCode: 0 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.test/v1/code/execute',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { authorization: 'Bearer tool-secret', 'content-type': 'application/json' },
+        body: JSON.stringify({ language: 'typescript', sourceCode: 'console.log(1)' }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it.each([
+    [
+      'HTTP failure',
+      Promise.resolve(new Response('nope', { status: 502 })),
+      'Code execution failed.',
+    ],
+    [
+      'malformed result',
+      Promise.resolve(new Response('{}', { status: 200 })),
+      'Invalid execution result.',
+    ],
+    ['network failure', () => Promise.reject(new Error('offline')), 'Code execution unavailable.'],
+  ])('returns a safe error for %s', async (_name, response, error) => {
+    fetchMock.mockImplementation(() => (typeof response === 'function' ? response() : response));
+    const { buildExecuteCodeTool } = await import('./execute-code-tool');
+    expect(
+      JSON.parse(await buildExecuteCodeTool()!.handler({ language: 'python', sourceCode: '1' })),
+    ).toEqual({ error });
+  });
+});

--- a/apps/chat-bot/src/app/api/chat/tools/execute-code-tool.ts
+++ b/apps/chat-bot/src/app/api/chat/tools/execute-code-tool.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import { env } from '@/env';
+import type { ToolDefinition, ToolRegistration } from './types';
+
+export const MAX_SOURCE_CODE_LENGTH = 256_000;
+const requestSchema = z
+  .object({
+    language: z.enum(['python', 'javascript', 'typescript']),
+    sourceCode: z.string().min(1).max(MAX_SOURCE_CODE_LENGTH),
+  })
+  .strict();
+const resultSchema = z.object({
+  status: z.string(),
+  stdout: z.string(),
+  stderr: z.string(),
+  compileOutput: z.string(),
+  message: z.string(),
+  exitCode: z.number().nullable(),
+  time: z.string().nullable(),
+  memory: z.number().nullable(),
+});
+
+export function buildExecuteCodeTool(): ToolRegistration | null {
+  const definition: ToolDefinition = {
+    name: 'execute_code',
+    description: `Execute sandboxed Python, JavaScript, or TypeScript source code (maximum ${MAX_SOURCE_CODE_LENGTH} characters). Network access is disabled.`,
+    parameters: {
+      type: 'object',
+      properties: {
+        language: { type: 'string', enum: ['python', 'javascript', 'typescript'] },
+        sourceCode: { type: 'string', maxLength: MAX_SOURCE_CODE_LENGTH },
+      },
+      required: ['language', 'sourceCode'],
+      additionalProperties: false,
+    },
+  };
+  const handler = async (args: Record<string, unknown>): Promise<string> => {
+    const parsed = requestSchema.safeParse(args);
+    if (!parsed.success) return JSON.stringify({ error: 'Invalid execute_code arguments.' });
+    try {
+      const response = await fetch(`${env.apiUrl.replace(/\/$/, '')}/v1/code/execute`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${env.apiKey}`, 'content-type': 'application/json' },
+        body: JSON.stringify(parsed.data),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) return JSON.stringify({ error: 'Code execution failed.' });
+      const result = resultSchema.safeParse(await response.json());
+      return result.success
+        ? JSON.stringify(result.data)
+        : JSON.stringify({ error: 'Invalid execution result.' });
+    } catch {
+      return JSON.stringify({ error: 'Code execution unavailable.' });
+    }
+  };
+  return { definition, handler };
+}

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.test.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.test.ts
@@ -310,4 +310,27 @@ describe('sendLearningScenarioMessage', () => {
       }),
     );
   });
+
+  it('uses the shared learning-scenario owner federal-state code execution toggle', async () => {
+    mocks.getUserAndContextByUserIdMock.mockResolvedValue({
+      ...teacherUserAndContext,
+      federalState: {
+        ...teacherUserAndContext.federalState,
+        featureToggles: { isAgenticChatEnabled: true, isCodeExecutionEnabled: true },
+      },
+    });
+    mocks.buildToolsMock.mockResolvedValue({ toolRegistry: {} });
+
+    const { sendLearningScenarioMessage } = await import('./learning-scenario-chat-service');
+    await sendLearningScenarioMessage({
+      learningScenarioId: learningScenario.id,
+      inviteCode: 'invite-code',
+      messages,
+      modelId: model.id,
+    });
+
+    expect(mocks.buildToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ allowCodeExecution: true }),
+    );
+  });
 });

--- a/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
+++ b/apps/chat-bot/src/app/api/learning-scenario/learning-scenario-chat-service.ts
@@ -177,6 +177,9 @@ export async function sendLearningScenarioMessage({
       sourceUrls: processedUrls,
       allowWebTools,
       allowMundoSearch: false,
+      allowCodeExecution:
+        agenticChatEnabled &&
+        (teacherUserAndContext.federalState.featureToggles.isCodeExecutionEnabled ?? false),
       onWebSearchResults: (results) => {
         update(
           encodeChatStreamEvent({

--- a/devops/docker/docker-compose.yml
+++ b/devops/docker/docker-compose.yml
@@ -24,6 +24,9 @@ services:
     depends_on:
       fix-keycloak-volume-ownership:
         condition: service_completed_successfully
+    networks:
+      - default
+      - judge0-private
 
   # Fix keycloak volume permissions (runs with uid 1000)
   fix-keycloak-volume-ownership:
@@ -170,6 +173,8 @@ services:
       API_NAME: ais-chat
       API_KEY: ais-chat-api_api-key
       PORT: 3002
+      JUDGE0_URL: http://judge0-server:2358
+      JUDGE0_TOKEN: ${JUDGE0_TOKEN:?set JUDGE0_TOKEN}
 
       # Logging
       LOG_LEVEL: info
@@ -371,3 +376,8 @@ volumes:
   bifrost_data:
   rustfs_data:
   xberg_cache:
+
+networks:
+  judge0-private:
+    external: true
+    name: judge0-private

--- a/devops/docker/judge0/README.md
+++ b/devops/docker/judge0/README.md
@@ -1,0 +1,39 @@
+# Local Judge0 CE 1.13.1
+
+This directory provides an isolated Judge0 CE deployment for the code gateway. Images are
+version-pinned: Judge0 CE `1.13.1`, PostgreSQL `16.8-alpine`, and Redis `7.4.2-alpine`.
+
+```sh
+export JUDGE0_DB_PASSWORD='use-a-local-secret'
+export JUDGE0_TOKEN='use-a-different-random-secret-at-least-32-characters'
+docker compose -f devops/docker/judge0/docker-compose.yml up -d
+```
+
+The compose network is internal. PostgreSQL and Redis publish no ports. Judge0 binds only to the
+host loopback interface at `127.0.0.1:2358` so the repository's normal host-run API can reach it;
+it is not reachable from the LAN or internet. Set `JUDGE0_URL=http://127.0.0.1:2358`. Do not expose
+Judge0 through a reverse proxy or change this to a wildcard host binding.
+
+The database and Redis use ephemeral storage, and the gateway deletes every submission after
+collecting its bounded result, including timed-out submissions. Restarting this stack clears any
+submission left behind by an abrupt process or host failure.
+
+For the packaged `devops/docker/docker-compose.yml` stack, start this Judge0 compose first. Its
+named private network is attached to Keycloak's shared network namespace, and the packaged API uses
+`JUDGE0_URL=http://judge0-server:2358` without publishing Judge0 publicly.
+
+Workers are intentionally `privileged`, as required by Judge0's sandbox implementation. This is
+acceptable only on a dedicated trusted host/VM with no unrelated workloads. In production put
+workers on a separate hardened host/VM and restrict access so only the unprivileged API gateway
+can reach the Judge0 server. The API never mounts the Docker socket and never runs Docker.
+
+Judge0 CE 1.13.1's `isolate` sandbox requires the cgroup v1 memory controller. Current WSL kernels
+support cgroup v2 only, so code execution does not work under WSL even though the services themselves
+run in Docker. Docker-in-Docker does not help because nested containers still share the WSL kernel.
+Use a dedicated cgroup-v1-capable Linux VM for local integration and production deployment.
+
+The gateway always sends `enable_network: false` and fixed resource limits; do not weaken these
+values through request fields or environment overrides. Judge0's dangerous features remain
+disabled by the worker configuration, and all Judge0 endpoints require a private token. The API
+also limits each process to four concurrent
+executions. Scale and rate-limit the API deliberately rather than exposing Judge0 directly.

--- a/devops/docker/judge0/docker-compose.yml
+++ b/devops/docker/judge0/docker-compose.yml
@@ -1,0 +1,74 @@
+services:
+  judge0-db:
+    image: postgres:16.8-alpine
+    environment:
+      POSTGRES_DB: judge0
+      POSTGRES_USER: judge0
+      POSTGRES_PASSWORD: ${JUDGE0_DB_PASSWORD:?set JUDGE0_DB_PASSWORD}
+    tmpfs:
+      - /var/lib/postgresql/data
+    networks: [judge0-private]
+    restart: unless-stopped
+
+  judge0-redis:
+    image: redis:7.4.2-alpine
+    command: ['redis-server', '--save', '', '--appendonly', 'no']
+    networks: [judge0-private]
+    restart: unless-stopped
+
+  judge0-server:
+    image: judge0/judge0:1.13.1
+    command: ['./scripts/server']
+    environment: &judge0-env
+      POSTGRES_HOST: judge0-db
+      POSTGRES_DB: judge0
+      POSTGRES_USER: judge0
+      POSTGRES_PASSWORD: ${JUDGE0_DB_PASSWORD:?set JUDGE0_DB_PASSWORD}
+      REDIS_HOST: judge0-redis
+      JUDGE0_TELEMETRY_ENABLE: 'false'
+      ENABLE_WAIT_RESULT: 'false'
+      ENABLE_COMPILER_OPTIONS: 'false'
+      ENABLE_COMMAND_LINE_ARGUMENTS: 'false'
+      ENABLE_SUBMISSION_DELETE: 'true'
+      ENABLE_BATCHED_SUBMISSIONS: 'false'
+      ENABLE_CALLBACKS: 'false'
+      ENABLE_ADDITIONAL_FILES: 'false'
+      AUTHN_TOKEN: ${JUDGE0_TOKEN:?set JUDGE0_TOKEN}
+      AUTHZ_TOKEN: ${JUDGE0_TOKEN:?set JUDGE0_TOKEN}
+      MAX_QUEUE_SIZE: '32'
+      ENABLE_NETWORK: 'false'
+      ALLOW_ENABLE_NETWORK: 'false'
+      ENABLE_PER_PROCESS_AND_THREAD_TIME_LIMIT: 'false'
+      ALLOW_ENABLE_PER_PROCESS_AND_THREAD_TIME_LIMIT: 'false'
+      CPU_TIME_LIMIT: '2'
+      MAX_CPU_TIME_LIMIT: '2'
+      WALL_TIME_LIMIT: '5'
+      MAX_WALL_TIME_LIMIT: '5'
+      MEMORY_LIMIT: '128000'
+      MAX_MEMORY_LIMIT: '128000'
+      MAX_PROCESSES_AND_OR_THREADS: '32'
+      MAX_MAX_PROCESSES_AND_OR_THREADS: '32'
+      MAX_FILE_SIZE: '1024'
+      MAX_MAX_FILE_SIZE: '1024'
+    depends_on: [judge0-db, judge0-redis]
+    networks:
+      - judge0-private
+      - judge0-loopback
+    ports:
+      - '127.0.0.1:2358:2358'
+    restart: unless-stopped
+
+  judge0-workers:
+    image: judge0/judge0:1.13.1
+    command: ['./scripts/workers']
+    privileged: true
+    environment: *judge0-env
+    depends_on: [judge0-server]
+    networks: [judge0-private]
+    restart: unless-stopped
+
+networks:
+  judge0-private:
+    name: judge0-private
+    internal: true
+  judge0-loopback:

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -207,6 +207,7 @@ export const federalStateFeatureTogglesSchema = z.object({
   isShareTemplateWithSchoolEnabled: z.boolean().default(true),
   isSharedPageLocaleDetectionEnabled: z.boolean().optional(),
   isAgenticChatEnabled: z.boolean().optional(),
+  isCodeExecutionEnabled: z.boolean().optional(),
   isImageGenerationEnabled: z.boolean().optional(),
   isWebSearchEnabled: z.boolean().optional(),
 });

--- a/packages/shared/src/db/seed/federal-state.ts
+++ b/packages/shared/src/db/seed/federal-state.ts
@@ -167,5 +167,6 @@ export const FEDERAL_STATES = FEDERAL_STATE_DEFINITIONS.filter((state) => {
     isAgenticChatEnabled: true,
     isImageGenerationEnabled: true,
     isWebSearchEnabled: true,
+    isCodeExecutionEnabled: false,
   },
 })) satisfies Array<Omit<FederalStateInsertModel, 'organizationId'>>;

--- a/turbo.json
+++ b/turbo.json
@@ -63,7 +63,11 @@
     "PORT",
     "SENTRY_PROFILE_SESSION_SAMPLE_RATE",
     "STAGE_DATABASE_URL",
-    "LOG_LEVEL"
+    "LOG_LEVEL",
+    "JUDGE0_URL",
+    "JUDGE0_TOKEN",
+    "JUDGE0_TIMEOUT_MS",
+    "JUDGE0_POLL_INTERVAL_MS"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
Adds a federal-state-gated `execute_code` tool for stateless Python, JavaScript, and TypeScript execution through an authenticated Judge0 gateway. It supports authenticated chats and owner-controlled shared character/learning-scenario chats, disables network access, applies strict execution and concurrency limits, deletes Judge0 submissions, uses ephemeral Judge0 storage, and excludes hidden code tool calls/results from durable chat history.

Includes the self-hosted Judge0 CE 1.13.1 Docker Compose stack, private networking, gateway authentication, admin toggle, documentation, and automated coverage. Formatting, lint, type checks, and the full unit test suite pass (897 passed, 3 skipped). The monorepo build was not rerun because it crashes the current WSL environment.

Important environment limitation: Judge0 is already containerized, but Judge0 CE 1.13.1's `isolate` worker requires the cgroup v1 memory controller. Current WSL supports cgroup v2 only. Docker containers and Docker-in-Docker share the WSL host kernel, so nesting Judge0 in Docker cannot provide the missing cgroup-v1 controller. Services start under WSL, but real executions end in `Internal Error` with `Failed to create control group /sys/fs/cgroup/memory/...`. A dedicated cgroup-v1-capable Linux VM/host is required to complete real Judge0 integration and the requested desktop/mobile equation-solving browser verification. Those screenshots and browser evidence are therefore intentionally outstanding on this draft PR.