### PR TITLE
TD-793: Normalize Anthropic models during Bifrost sync

### DIFF
--- a/packages/api-database/src/bifrost-provider-sync/provider-config-builder/providers.ts
+++ b/packages/api-database/src/bifrost-provider-sync/provider-config-builder/providers.ts
@@ -15,14 +15,21 @@ function buildKey(
   return {
     name: `ais-chat-${providerKey.id}`,
     value,
-    models: [...new Set(activeMappings.map(({ model }) => model.name))].sort(),
+    models: [...new Set(activeMappings.map(({ model }) => getBifrostModelName(model.name)))].sort(),
     aliases: Object.fromEntries(
-      activeMappings.map(({ model, upstreamModelName }) => [model.name, upstreamModelName]),
+      activeMappings.map(({ model, upstreamModelName }) => [
+        getBifrostModelName(model.name),
+        upstreamModelName,
+      ]),
     ),
     weight: providerKey.weight,
     enabled: providerKey.isEnabled,
     ...extra,
   };
+}
+
+function getBifrostModelName(modelName: string): string {
+  return modelName.replace(/^anthropic\//, '');
 }
 
 export function buildAzureProviderConfig(

--- a/packages/api-database/src/bifrost-provider-sync/provider-config-builder/providers.ts
+++ b/packages/api-database/src/bifrost-provider-sync/provider-config-builder/providers.ts
@@ -12,16 +12,19 @@ function buildKey(
   const activeMappings = providerKey.models.filter(
     ({ model }) => !model.isDeleted && model.useBifrost,
   );
+  const modelMappings = activeMappings.flatMap(({ model, upstreamModelName }) => {
+    const bifrostModelName = getBifrostModelName(model.name);
+    const bifrostUpstreamModelName = getBifrostModelName(upstreamModelName);
+    return [
+      [model.name, bifrostUpstreamModelName],
+      [bifrostModelName, bifrostUpstreamModelName],
+    ] as const;
+  });
   return {
     name: `ais-chat-${providerKey.id}`,
     value,
-    models: [...new Set(activeMappings.map(({ model }) => getBifrostModelName(model.name)))].sort(),
-    aliases: Object.fromEntries(
-      activeMappings.map(({ model, upstreamModelName }) => [
-        getBifrostModelName(model.name),
-        upstreamModelName,
-      ]),
-    ),
+    models: [...new Set(modelMappings.map(([modelName]) => modelName))].sort(),
+    aliases: Object.fromEntries(modelMappings),
     weight: providerKey.weight,
     enabled: providerKey.isEnabled,
     ...extra,

--- a/packages/api-database/src/bifrost-provider-sync/provider-config-builder/providers.ts
+++ b/packages/api-database/src/bifrost-provider-sync/provider-config-builder/providers.ts
@@ -15,10 +15,7 @@ function buildKey(
   const modelMappings = activeMappings.flatMap(({ model, upstreamModelName }) => {
     const bifrostModelName = getBifrostModelName(model.name);
     const bifrostUpstreamModelName = getBifrostModelName(upstreamModelName);
-    return [
-      [model.name, bifrostUpstreamModelName],
-      [bifrostModelName, bifrostUpstreamModelName],
-    ] as const;
+    return [[bifrostModelName, bifrostUpstreamModelName]] as const;
   });
   return {
     name: `ais-chat-${providerKey.id}`,


### PR DESCRIPTION
Normalize Anthropic logical model names before syncing Bifrost provider keys. Bifrost receives only the bare model name and alias value, matching the successful request shape observed in local Bifrost.

Verified by saving the model in admin, sending an Anthropic chat message through the running local app, and receiving a successful response. Formatting, lint, type checking, and API-database tests pass.