### PR TITLE
ci: run e2e container dependencies via docker compose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,8 +30,6 @@ updates:
 
   - package-ecosystem: 'docker-compose'
     directories:
-      - '/apps/chat-bot/e2e'
-      - '/apps/chat-bot/e2e/mock'
       - '/devops/docker'
     labels: ['dependencies']
     schedule:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,44 +12,6 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    services:
-      postgres-dialog:
-        image: pgvector/pgvector:pg16
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: admin
-          POSTGRES_PASSWORD: test1234
-          POSTGRES_DB: app_db
-        options: >-
-          --health-cmd "pg_isready -U admin -d app_db"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      postgres-api:
-        image: pgvector/pgvector:pg16
-        ports:
-          - 6543:5432
-        env:
-          POSTGRES_USER: admin
-          POSTGRES_PASSWORD: test1234
-          POSTGRES_DB: api_db
-        options: >-
-          --health-cmd "pg_isready -U admin -d api_db"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      valkey:
-        image: ghcr.io/valkey-io/valkey:9.1.0-alpine
-        ports:
-          - 6379:6379
-      rabbitmq:
-        image: rabbitmq:4
-        ports:
-          - 5672:5672
-        env:
-          RABBITMQ_DEFAULT_PASS: password
-          RABBITMQ_DEFAULT_USER: user
 
     env:
       DATABASE_URL: postgresql://admin:test1234@127.0.0.1:5432/app_db
@@ -58,7 +20,7 @@ jobs:
       VIDIS_CLIENT_ID: ais-chat-e2e-client
       VIDIS_CLIENT_SECRET: ClientSecret-e2e
       VIDIS_ISSUER_URI: http://localhost:8080/realms/ais-chat-local
-      API_DATABASE_URL: postgresql://admin:test1234@127.0.0.1:6543/api_db
+      API_DATABASE_URL: postgresql://admin:test1234@127.0.0.1:5432/api_db
       API_URL: http://localhost:3002
       API_KEY: ApiKeyForAISChatApiAdminApi
       ENCRYPTION_KEY: EncryptionKeyForEncryptedApiKeysToAISChatApi
@@ -85,47 +47,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      # Keycloak container cannot be started under services, because it needs to mount files from the repo
-      - name: Start keycloak container (in background)
-        run: |
-          docker run \
-            --name keycloak \
-            -v "$PWD/devops/docker/keycloak:/opt/keycloak/data/import" \
-            -p 8080:8080 \
-            -e CLIENT_NAME=$VIDIS_CLIENT_ID -e CLIENT_SECRET=$VIDIS_CLIENT_SECRET \
-            --entrypoint /opt/keycloak/data/import/entrypoint.sh \
-            quay.io/keycloak/keycloak:26.7.1 > /tmp/keycloak.log 2>&1 &
-
-      # crawl4ai is not started under services because its large image (~40s pull) would delay the whole pipeline
-      - name: Start crawl4ai container (in background)
-        run: |
-          docker run \
-            --name crawl4ai \
-            --shm-size=2gb \
-            -p 11235:11235 \
-            -e CRAWL4AI_API_TOKEN=$CRAWL4AI_API_TOKEN \
-            unclecode/crawl4ai:0.9.2 > /tmp/crawl4ai.log 2>&1 &
-
-      # xberg is not started under services because its startup time would delay the whole pipeline
-      - name: Start xberg container (in background)
-        run: |
-          docker run \
-            --name xberg \
-            -p 8000:8000 \
-            -e XBERG_MAX_UPLOAD_SIZE_MB=$XBERG_MAX_UPLOAD_SIZE_MB \
-            ghcr.io/xberg-io/xberg:1.0.14-core > /tmp/xberg.log 2>&1 &
-
-      - name: Start bifrost container (in background)
-        run: |
-          docker run \
-            --name bifrost \
-            --network host \
-            -v "$PWD/devops/docker/bifrost/config.json:/app/data/config.json:ro" \
-            -e APP_PORT=8089 \
-            -e BIFROST_ADMIN_USERNAME=admin \
-            -e BIFROST_ADMIN_PASSWORD=admin \
-            -e BIFROST_API_KEY=sk-bf-example-key \
-            ghcr.io/maximhq/bifrost:v1.6.8 > /tmp/bifrost.log 2>&1 &
+      # Starts all e2e container dependencies in the background using the same compose file as
+      # local dev. Later steps only block on the specific containers they actually need, once needed.
+      - name: Start e2e container dependencies (in background)
+        run: docker compose -f devops/docker/docker-compose.local.yml up -d --build &
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -134,10 +59,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-
-      - name: Start mock-llm server
-        run: |
-          node devops/docker/mock-llm/server.mjs > /tmp/mock-llm.log 2>&1 &
 
       - name: Install dependencies
         run: pnpm install
@@ -153,6 +74,9 @@ jobs:
 
       - name: Install Playwright browsers
         run: pnpm --filter ais-chat-app exec playwright install chromium firefox
+
+      - name: Wait for postgres and bifrost
+        run: docker compose -f devops/docker/docker-compose.local.yml up -d --wait postgres bifrost
 
       - name: Start ais-chat-api
         run: |
@@ -217,6 +141,9 @@ jobs:
           NODE_ENV: test
           LINKUP_API_KEY: ${{ secrets.LINKUP_API_KEY }}
 
+      - name: Wait for remaining e2e container dependencies
+        run: docker compose -f devops/docker/docker-compose.local.yml up -d --wait
+
       - name: Run E2E tests (app)
         run: pnpm --filter ais-chat-app e2e
         env:
@@ -258,32 +185,6 @@ jobs:
           echo "=== ais-chat-app logs ==="
           cat /tmp/ais-chat-app.log || true
 
-      - name: Print crawl4ai logs
+      - name: Print container logs
         if: always()
-        run: |
-          echo "=== crawl4ai logs ==="
-          cat /tmp/crawl4ai.log || true
-
-      - name: Print xberg logs
-        if: always()
-        run: |
-          echo "=== xberg logs ==="
-          cat /tmp/xberg.log || true
-
-      - name: Print bifrost logs
-        if: always()
-        run: |
-          echo "=== bifrost logs ==="
-          cat /tmp/bifrost.log || true
-
-      - name: Print mock-llm logs
-        if: always()
-        run: |
-          echo "=== mock-llm logs ==="
-          cat /tmp/mock-llm.log || true
-
-      - name: Print keycloak logs
-        if: always()
-        run: |
-          echo "=== keycloak logs ==="
-          cat /tmp/keycloak.log || true
+        run: docker compose -f devops/docker/docker-compose.local.yml logs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter ais-chat-app exec playwright install chromium firefox
 
-      - name: Wait for postgres and bifrost
-        run: docker compose -f devops/docker/docker-compose.local.yml up -d --wait postgres bifrost
+      - name: Wait for postgres
+        run: docker compose -f devops/docker/docker-compose.local.yml up -d --wait postgres
 
       - name: Start ais-chat-api
         run: |
@@ -94,6 +94,9 @@ jobs:
           done
         env:
           PORT: 3002
+
+      - name: Wait for bifrost and mock-llm
+        run: docker compose -f devops/docker/docker-compose.local.yml up -d --wait bifrost mock-llm
 
       - name: Seed ais-chat-api database
         # db:seed will print the generated API KEY on the console
@@ -114,7 +117,7 @@ jobs:
           LLM_GPT5MINI_API_KEY: ${{ secrets.LLM_GPT5MINI_API_KEY }}
           LLM_GPT5MINI_BASE_URL: ${{ secrets.LLM_GPT5MINI_BASE_URL }}
           LLM_MOCK_API_KEY: mock-api-key
-          LLM_MOCK_BASE_URL: http://localhost:6556
+          LLM_MOCK_BASE_URL: http://mock-llm:6556
 
       - name: Run migrations and seed database (if applicable)
         run: pnpm --filter @ais-chat/shared db:migrate && pnpm --filter @ais-chat/shared db:seed
@@ -140,9 +143,6 @@ jobs:
         env:
           NODE_ENV: test
           LINKUP_API_KEY: ${{ secrets.LINKUP_API_KEY }}
-
-      - name: Wait for remaining e2e container dependencies
-        run: docker compose -f devops/docker/docker-compose.local.yml up -d --wait
 
       - name: Run E2E tests (app)
         run: pnpm --filter ais-chat-app e2e

--- a/devops/docker/docker-compose.local.yml
+++ b/devops/docker/docker-compose.local.yml
@@ -39,8 +39,8 @@ services:
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
-      CLIENT_NAME: ais-chat-dev-client
-      CLIENT_SECRET: ClientSecret
+      CLIENT_NAME: ${VIDIS_CLIENT_ID:-ais-chat-dev-client}
+      CLIENT_SECRET: ${VIDIS_CLIENT_SECRET:-ClientSecret}
     entrypoint: /opt/keycloak/data/import/entrypoint.sh
     volumes:
       - keycloak_data:/opt/keycloak/data/h2

--- a/devops/docker/docker-compose.local.yml
+++ b/devops/docker/docker-compose.local.yml
@@ -131,6 +131,12 @@ services:
     volumes:
       - ./bifrost/config.json:/app/data/config.json:ro
       - bifrost_data:/app/data
+    # bifrost is reliably up within ~1s; poll faster than the image's default 30s interval.
+    healthcheck:
+      interval: 2s
+      timeout: 2s
+      retries: 5
+      start_period: 2s
 
 volumes:
   bifrost_data:

--- a/devops/docker/mock-llm/Dockerfile
+++ b/devops/docker/mock-llm/Dockerfile
@@ -2,6 +2,6 @@ FROM node:24.19.0-alpine
 WORKDIR /app
 COPY server.mjs .
 EXPOSE 6556
-HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=5s \
+HEALTHCHECK --interval=1s --timeout=2s --retries=3 --start-period=1s \
   CMD wget -qO- http://127.0.0.1:6556/health || exit 1
 CMD ["node", "server.mjs"]


### PR DESCRIPTION
- Replaces the e2e workflow's GitHub Actions `services:` block and per-container `docker run` steps with the same `docker-compose.local.yml` used for local dev, started in the background right after checkout. This fixes two issues: Dependabot never updated image tags used in `e2e.yml` (it only scans compose files), and new services now start automatically in the e2e pipeline without any workflow changes.
- Waits are staggered: postgres before starting `ais-chat-api`, bifrost/mock-llm before seeding (which registers the mock-llm provider with Bifrost); everything else just runs in the background and is used whenever the tests need it.
- Consolidates the two postgres containers into the single multi-db instance already used locally.
- Points Bifrost at the `mock-llm` container hostname instead of `localhost`, since mock-llm now runs as a Compose service.
- Tightens the mock-llm/bifrost healthcheck cadence so readiness is detected within a couple seconds instead of their default (much slower) intervals.
- Removes stale `docker-compose` dependabot entries for `apps/chat-bot/e2e` and `apps/chat-bot/e2e/mock`, which don't exist.