### PR TITLE
ci: use --frozen-lockfile for pnpm install

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,7 +52,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
   check_formatting:
     runs-on: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Check formatting
         run: pnpm run format:check
 
@@ -86,7 +86,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Cache turbo build cache
         uses: actions/cache@v6
         with:
@@ -111,7 +111,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Cache turbo build cache
         uses: actions/cache@v6
         with:
@@ -154,7 +154,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Cache turbo build cache
         uses: actions/cache@v6
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -140,7 +140,7 @@ jobs:
           node devops/docker/mock-llm/server.mjs > /tmp/mock-llm.log 2>&1 &
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
         uses: actions/cache@v6


### PR DESCRIPTION
GitHub Copilot generated an incorrect `pnpm-lock.yaml` in #1265, which was merged to `main` since `pnpm install` only warned about the broken lockfile instead of failing. The Docker build later failed for real (it already uses `--frozen-lockfile`).

Add `--frozen-lockfile` to all `pnpm install` steps in `checks.yml` and `e2e.yml` so CI fails immediately on a broken or out-of-sync lockfile, matching Docker build behavior.