### PR TITLE
TD-1478: Adopt Cache Components in chat-bot and admin

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -25,9 +25,9 @@ const baseNextConfig: NextConfig = {
   // https://nextjs.org/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files
   output: 'standalone',
   reactCompiler: true,
+  cacheComponents: true,
   productionBrowserSourceMaps: !isDevBuild,
   experimental: {
-    useCache: true,
     // Speed up dev builds by pre-bundling heavy packages instead of re-resolving on every HMR
     optimizePackageImports: ['@ais-chat/ui', '@ais-chat/shared', '@ais-chat/ai-core'],
     // Run the React Compiler natively inside Turbopack instead of via Babel

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/layout.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/layout.tsx
@@ -2,6 +2,10 @@ import type { ReactNode } from 'react';
 import TwoColumnLayout from '@/components/layout/TwoColumnLayout';
 import { OrganizationSidebar } from './OrganizationSidebar';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function OrganizationLayout({
   children,
   params,

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/llms/[llmId]/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/llms/[llmId]/page.tsx
@@ -2,7 +2,9 @@ import { getLargeLanguageModelsAction } from '../actions';
 import { LargeLanguageModelDetailView } from './LargeLanguageModelDetailView';
 import { getProviderKeysAction } from '../../provider-keys/actions';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function Page(
   props: PageProps<'/organizations/[organizationId]/llms/[llmId]'>,

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/llms/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/llms/page.tsx
@@ -1,6 +1,10 @@
 import { LargeLanguageModelListView } from './LargeLanguageModelListView';
 import { getLargeLanguageModelsAction } from './actions';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function LargeLanguageModelsPage(
   props: PageProps<'/organizations/[organizationId]/llms'>,
 ) {

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/page.tsx
@@ -1,6 +1,10 @@
 import { redirect } from 'next/navigation';
 import { ROUTES } from '@/consts/routes';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function OrganizationPage(
   props: PageProps<'/organizations/[organizationId]'>,
 ) {

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/[projectId]/api-keys/[apiKeyId]/model-mappings/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/[projectId]/api-keys/[apiKeyId]/model-mappings/page.tsx
@@ -1,6 +1,8 @@
 import { ModelApiKeyMappingListView } from './ModelApiKeyMappingListView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function ModelApiKeyMappingsPage(
   props: PageProps<'/organizations/[organizationId]/projects/[projectId]/api-keys/[apiKeyId]/model-mappings'>,

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/[projectId]/api-keys/[apiKeyId]/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/[projectId]/api-keys/[apiKeyId]/page.tsx
@@ -1,6 +1,10 @@
 import { getApiKeyByIdAction } from '../actions';
 import { ApiKeyDetailView } from '../ApiKeyDetailView';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function ApiKeyDetailPage(
   props: PageProps<'/organizations/[organizationId]/projects/[projectId]/api-keys/[apiKeyId]'>,
 ) {

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/[projectId]/api-keys/new/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/[projectId]/api-keys/new/page.tsx
@@ -1,5 +1,9 @@
 import { ApiKeyDetailView } from '../ApiKeyDetailView';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function NewApiKeyPage(
   props: PageProps<'/organizations/[organizationId]/projects/[projectId]/api-keys/new'>,
 ) {

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/[projectId]/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/[projectId]/page.tsx
@@ -1,6 +1,8 @@
 import ProjectDetailView from './ProjectDetailView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function Page(
   props: PageProps<'/organizations/[organizationId]/projects/[projectId]'>,

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/projects/page.tsx
@@ -1,6 +1,8 @@
 import { ProjectListView } from './ProjectListView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function ProjectsPage(
   props: PageProps<'/organizations/[organizationId]/projects'>,

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/provider-keys/[providerKeyId]/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/provider-keys/[providerKeyId]/page.tsx
@@ -2,7 +2,9 @@ import { notFound } from 'next/navigation';
 import { getProviderKeysAction } from '../actions';
 import { ProviderKeyDetailView } from './ProviderKeyDetailView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function ProviderKeyPage(
   props: PageProps<'/organizations/[organizationId]/provider-keys/[providerKeyId]'>,

--- a/apps/admin/src/app/(telli-api)/organizations/[organizationId]/provider-keys/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/[organizationId]/provider-keys/page.tsx
@@ -1,6 +1,10 @@
 import { getProviderKeysAction } from './actions';
 import { ProviderKeyListView } from './ProviderKeyListView';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function ProviderKeysPage(
   props: PageProps<'/organizations/[organizationId]/provider-keys'>,
 ) {

--- a/apps/admin/src/app/(telli-api)/organizations/page.tsx
+++ b/apps/admin/src/app/(telli-api)/organizations/page.tsx
@@ -1,5 +1,9 @@
 import { OrganizationListView } from './OrganizationListView';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function OrganizationsPage() {
   return <OrganizationListView />;
 }

--- a/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/api-key/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/api-key/page.tsx
@@ -1,7 +1,9 @@
 import { getFederalStateById } from '@shared/federal-states/federal-state-service';
 import { FederalStateUpdateApiKey } from './FederalStateUpdateApiKey';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function Page(
   props: PageProps<'/ais-chat-app/federal-states/[federalStateId]/api-key'>,

--- a/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/page.tsx
@@ -4,7 +4,9 @@ import { FederalStateView } from './FederalStateDetailView';
 import { Sidebar, SidebarItem } from '@/components/navigation/Sidebar';
 import { ROUTES } from '@/consts/routes';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function Page(
   props: PageProps<'/ais-chat-app/federal-states/[federalStateId]'>,

--- a/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/vouchers/new/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/vouchers/new/page.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import VoucherCreateView from './VoucherCreateView';
 import { auth } from '@/auth';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function Page(
   props: PageProps<'/ais-chat-app/federal-states/[federalStateId]/vouchers/new'>,
 ) {

--- a/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/vouchers/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/federal-states/[federalStateId]/vouchers/page.tsx
@@ -1,7 +1,9 @@
 import { getVouchersAction } from './actions';
 import VoucherListView from './VoucherListView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function VouchersByStatePage(
   props: PageProps<'/ais-chat-app/federal-states/[federalStateId]/vouchers'>,

--- a/apps/admin/src/app/ais-chat-app/federal-states/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/federal-states/page.tsx
@@ -2,7 +2,9 @@ import TwoColumnLayout from '@/components/layout/TwoColumnLayout';
 import FederalStateListView from './FederalStateListView';
 import { AdminAppSidebar } from '../AdminAppSidebar';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default function FederalStatesPage() {
   return <TwoColumnLayout sidebar={<AdminAppSidebar />} page={<FederalStateListView />} />;

--- a/apps/admin/src/app/ais-chat-app/info-banners/[infoBannerId]/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/info-banners/[infoBannerId]/page.tsx
@@ -7,7 +7,9 @@ import {
 } from '../actions';
 import InfoBannerEditorView from '../InfoBannerEditorView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function InfoBannerDetailPage(
   props: PageProps<'/ais-chat-app/info-banners/[infoBannerId]'>,

--- a/apps/admin/src/app/ais-chat-app/info-banners/new/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/info-banners/new/page.tsx
@@ -3,7 +3,9 @@ import { AdminAppSidebar } from '../../AdminAppSidebar';
 import { getFederalStatesAction } from '../actions';
 import InfoBannerEditorView from '../InfoBannerEditorView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function NewInfoBannerPage() {
   const federalStates = await getFederalStatesAction();

--- a/apps/admin/src/app/ais-chat-app/info-banners/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/info-banners/page.tsx
@@ -2,7 +2,9 @@ import TwoColumnLayout from '@/components/layout/TwoColumnLayout';
 import { AdminAppSidebar } from '../AdminAppSidebar';
 import InfoBannerListView from './InfoBannerListView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default function InfoBannersPage() {
   return <TwoColumnLayout sidebar={<AdminAppSidebar />} page={<InfoBannerListView />} />;

--- a/apps/admin/src/app/ais-chat-app/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/page.tsx
@@ -1,6 +1,10 @@
 import TwoColumnLayout from '@/components/layout/TwoColumnLayout';
 import { AdminAppSidebar } from './AdminAppSidebar';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default function Page() {
   return <TwoColumnLayout sidebar={<AdminAppSidebar />} page={<div></div>} />;
 }

--- a/apps/admin/src/app/ais-chat-app/static-models/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/static-models/page.tsx
@@ -3,7 +3,9 @@ import { AdminAppSidebar } from '../AdminAppSidebar';
 import { getStaticModelConfigurationAction } from './actions';
 import StaticModelConfigurationView from './StaticModelConfigurationView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function StaticModelsPage() {
   const result = await getStaticModelConfigurationAction();

--- a/apps/admin/src/app/ais-chat-app/suspensions/[entityType]/[entityId]/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/suspensions/[entityType]/[entityId]/page.tsx
@@ -5,7 +5,9 @@ import { headers } from 'next/headers';
 import { getChatBotEntityUrl } from '../../utils';
 import { SuspensionRequestItemDetailView } from './SuspensionRequestItemDetailView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function SuspensionRequestPage(
   props: PageProps<'/ais-chat-app/suspensions/[entityType]/[entityId]'>,

--- a/apps/admin/src/app/ais-chat-app/suspensions/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/suspensions/page.tsx
@@ -2,7 +2,9 @@ import TwoColumnLayout from '@/components/layout/TwoColumnLayout';
 import { AdminAppSidebar } from '../AdminAppSidebar';
 import SuspensionRequestEntitiesOverview from './SuspensionRequestEntitiesOverview';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function SuspensionsPage() {
   return (

--- a/apps/admin/src/app/ais-chat-app/templates/[templateType]/[templateId]/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/templates/[templateType]/[templateId]/page.tsx
@@ -1,7 +1,9 @@
 import TemplateDetailView from './TemplateDetailView';
 import { isTemplateType } from '@shared/templates/template';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function Page(
   props: PageProps<'/ais-chat-app/templates/[templateType]/[templateId]'>,

--- a/apps/admin/src/app/ais-chat-app/templates/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/templates/page.tsx
@@ -2,7 +2,9 @@ import TwoColumnLayout from '@/components/layout/TwoColumnLayout';
 import { AdminAppSidebar } from '../AdminAppSidebar';
 import TemplateListView from './TemplateListView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default function Page() {
   return <TwoColumnLayout sidebar={<AdminAppSidebar />} page={<TemplateListView />} />;

--- a/apps/admin/src/app/ais-chat-app/tool-call-costs/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/tool-call-costs/page.tsx
@@ -3,7 +3,9 @@ import { getToolCallCostByName } from '@shared/tool-call-costs/tool-call-cost-se
 import { AdminAppSidebar } from '../AdminAppSidebar';
 import ToolCallCostListView from './ToolCallCostListView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : 'Ein Fehler ist aufgetreten.';

--- a/apps/admin/src/app/ais-chat-app/url-presets/page.tsx
+++ b/apps/admin/src/app/ais-chat-app/url-presets/page.tsx
@@ -2,7 +2,9 @@ import TwoColumnLayout from '@/components/layout/TwoColumnLayout';
 import { AdminAppSidebar } from '../AdminAppSidebar';
 import { UrlPresetsListView } from './UrlPresetsListView';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default function Page() {
   return <TwoColumnLayout sidebar={<AdminAppSidebar />} page={<UrlPresetsListView />} />;

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -7,6 +7,10 @@ import { Toaster } from '@ui/components/toaster';
 import { buildPublicConfig } from '@shared/sentry/public-config';
 import { TooltipProvider } from '@ui/components/tooltip';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 const barlow = Barlow({
   weight: ['400', '500', '600', '700'],
   subsets: ['latin'],

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -1,3 +1,7 @@
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function Home() {
   return (
     <div>

--- a/apps/chat-bot/next.config.ts
+++ b/apps/chat-bot/next.config.ts
@@ -25,6 +25,7 @@ const baseNextConfig: NextConfig = {
   // https://nextjs.org/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files
   output: 'standalone',
   reactCompiler: true,
+  cacheComponents: true,
   images: {
     // When images are hosted on the same cloud as the application, access is routed on the local network and needs to be allowed
     dangerouslyAllowLocalIP: true,
@@ -34,7 +35,6 @@ const baseNextConfig: NextConfig = {
   },
   productionBrowserSourceMaps: !isDevBuild,
   experimental: {
-    useCache: true,
     // Speed up dev builds by pre-bundling heavy packages instead of re-resolving on every HMR
     optimizePackageImports: ['@ais-chat/ui', '@ais-chat/shared', '@ais-chat/ai-core'],
     // Run the React Compiler natively inside Turbopack instead of via Babel

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/[assistantId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/[assistantId]/page.tsx
@@ -7,7 +7,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('assistants.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/d/[assistantId]/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/d/[assistantId]/[conversationId]/page.tsx
@@ -14,7 +14,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 const searchParamsSchema = z.object({ model: z.string().optional() });
 

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/d/[assistantId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/d/[assistantId]/page.tsx
@@ -12,7 +12,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('assistants.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/editor/[assistantId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/editor/[assistantId]/page.tsx
@@ -7,7 +7,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('assistants.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/page.tsx
@@ -4,7 +4,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('assistants.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/[characterId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/[characterId]/page.tsx
@@ -8,7 +8,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/d/[characterId]/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/d/[characterId]/[conversationId]/page.tsx
@@ -20,7 +20,10 @@ import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { NotFoundError } from '@shared/error';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/d/[characterId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/d/[characterId]/page.tsx
@@ -15,7 +15,10 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/page.tsx
@@ -9,7 +9,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/share/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/share/page.tsx
@@ -7,6 +7,10 @@ import { calculateShareSessionState } from '@shared/sharing/calculate-share-sess
 import { type Metadata } from 'next';
 import CustomChatSharePage from '@/components/custom-chat/custom-chat-share-page';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');
   return {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/layout.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/layout.tsx
@@ -1,6 +1,10 @@
 import { getUser } from '@/auth/utils';
 import { notFound } from 'next/navigation';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function Layout({ children }: { children: React.ReactNode }) {
   const user = await getUser();
 

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/page.tsx
@@ -4,7 +4,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/custom/editor/[customGptId]/layout.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/custom/editor/[customGptId]/layout.tsx
@@ -1,5 +1,9 @@
 import { getUser } from '@/auth/utils';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function Layout({ children }: { children: React.ReactNode }) {
   await getUser();
 

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/custom/editor/[customGptId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/custom/editor/[customGptId]/page.tsx
@@ -5,7 +5,9 @@ import { getAssistantByUser } from '@shared/assistants/assistant-service';
 import { requireAuth } from '@/auth/requireAuth';
 import { handleErrorInServerComponent } from '@/error/handle-error-in-server-component';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 const searchParamsSchema = z.object({
   create: z.string().optional().default('false'),

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/d/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/d/[conversationId]/page.tsx
@@ -16,7 +16,9 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { utils } from '@shared/utils';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('common.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/image-generation/d/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/image-generation/d/[conversationId]/page.tsx
@@ -14,7 +14,9 @@ import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { ImageAspectRatioProvider } from '@/components/image-generation/image-aspect-ratio-provider';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('image-generation.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/image-generation/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/image-generation/page.tsx
@@ -12,7 +12,9 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { ImageAspectRatioProvider } from '@/components/image-generation/image-aspect-ratio-provider';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('image-generation.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/layout.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/layout.tsx
@@ -22,7 +22,10 @@ import {
   getUsedBudgetInCentByUser,
 } from '@shared/users/user-budget-service';
 
-export const dynamic = 'force-dynamic';
+// Block: reads the user's session and budget/model data synchronously for every
+// route under it. Revisit by streaming these behind a <Suspense> boundary if
+// instant navigation is desired.
+export const instant = false;
 
 export default async function ChatLayout({ children }: { children: React.ReactNode }) {
   const t = await getTranslations('errors');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/[learningScenarioId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/[learningScenarioId]/page.tsx
@@ -7,7 +7,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/d/[learningScenarioId]/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/d/[learningScenarioId]/[conversationId]/page.tsx
@@ -19,7 +19,10 @@ import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { NotFoundError } from '@shared/error';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/d/[learningScenarioId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/d/[learningScenarioId]/page.tsx
@@ -14,7 +14,10 @@ import { getLearningScenarioForChatSession } from '@shared/learning-scenarios/le
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/page.tsx
@@ -9,7 +9,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/share/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/share/page.tsx
@@ -7,6 +7,10 @@ import { notFound } from 'next/navigation';
 import { type Metadata } from 'next';
 import CustomChatSharePage from '@/components/custom-chat/custom-chat-share-page';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');
   return {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/layout.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/layout.tsx
@@ -1,6 +1,10 @@
 import { requireAuth } from '@/auth/requireAuth';
 import { notFound } from 'next/navigation';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function Layout({ children }: { children: React.ReactNode }) {
   const { user } = await requireAuth();
 

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/page.tsx
@@ -4,7 +4,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/page.tsx
@@ -10,7 +10,9 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('common.page-titles');
@@ -20,7 +22,6 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  const id = generateUUID();
   const { user, federalState } = await requireAuth();
   const userAndContext = {
     ...user,
@@ -37,6 +38,8 @@ export default async function Page() {
   const defaultModelName = await getDefaultModelNameByFederalStateId(federalState.id, models);
 
   const logoElement = <Logo logoPath={userAndContext.federalState.pictureUrls?.logo} />;
+
+  const id = generateUUID();
 
   return (
     <LlmModelsProvider

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/top-up/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/top-up/page.tsx
@@ -4,6 +4,10 @@ import { requireAuth } from '@/auth/requireAuth';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('top-up.page-titles');
   return {

--- a/apps/chat-bot/src/app/(unauth)/login/error/page.tsx
+++ b/apps/chat-bot/src/app/(unauth)/login/error/page.tsx
@@ -4,7 +4,9 @@ import { getAuthErrorFromUrl, getFieldErrorsFromUrl } from '@shared/auth/authent
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('common.page-titles');

--- a/apps/chat-bot/src/app/(unauth)/login/page.tsx
+++ b/apps/chat-bot/src/app/(unauth)/login/page.tsx
@@ -6,7 +6,9 @@ import { getTranslations } from 'next-intl/server';
 import { redirect } from 'next/navigation';
 import { getHostByHeaders } from '@/utils/host';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('common.page-titles');

--- a/apps/chat-bot/src/app/(unauth)/ua/characters/[characterId]/dialog/page.tsx
+++ b/apps/chat-bot/src/app/(unauth)/ua/characters/[characterId]/dialog/page.tsx
@@ -15,6 +15,10 @@ import { NextIntlClientProvider } from 'next-intl';
 import { resolveSharingLocale } from '@/i18n/sharing-locale';
 import { loadTranslations } from '@/i18n/load-translations';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');
   return {

--- a/apps/chat-bot/src/app/(unauth)/ua/layout.tsx
+++ b/apps/chat-bot/src/app/(unauth)/ua/layout.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export const dynamic = 'force-dynamic';
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
 
 export default async function ChatLayout({ children }: { children: React.ReactNode }) {
   return <div className="relative flex flex-col h-dvh w-dvw overflow-hidden">{children}</div>;

--- a/apps/chat-bot/src/app/(unauth)/ua/learning-scenarios/[learningScenarioId]/dialog/page.tsx
+++ b/apps/chat-bot/src/app/(unauth)/ua/learning-scenarios/[learningScenarioId]/dialog/page.tsx
@@ -15,6 +15,10 @@ import { NextIntlClientProvider } from 'next-intl';
 import { resolveSharingLocale } from '@/i18n/sharing-locale';
 import { loadTranslations } from '@/i18n/load-translations';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');
   return {

--- a/apps/chat-bot/src/app/api/download-conversation/route.ts
+++ b/apps/chat-bot/src/app/api/download-conversation/route.ts
@@ -9,8 +9,6 @@ import {
 import z from 'zod';
 import { handleErrorInRoute } from '@/error/handle-error-in-route';
 
-export const dynamic = 'force-dynamic';
-
 const DEFAULT_GPT_NAME = 'AIS.chat';
 
 const downloadConversationParamsSchema = z.object({

--- a/apps/chat-bot/src/app/icon.tsx
+++ b/apps/chat-bot/src/app/icon.tsx
@@ -5,8 +5,6 @@ import { getMaybeUser } from '@/auth/utils';
 import { DEFAULT_DESIGN_CONFIGURATION } from '@/db/const';
 import { dbGetFederalStateByIdWithResult } from '@shared/db/functions/federal-state';
 
-export const dynamic = 'force-dynamic';
-
 export const size = {
   width: 32,
   height: 32,

--- a/apps/chat-bot/src/app/layout.tsx
+++ b/apps/chat-bot/src/app/layout.tsx
@@ -21,6 +21,11 @@ const barlow = Barlow({
   subsets: ['latin'],
 });
 
+// Block: the root layout reads the user's session and federal-state design configuration
+// synchronously to render <body> and theming for every route. Revisit by streaming this
+// behind a <Suspense> boundary if instant navigation for the whole app is desired.
+export const instant = false;
+
 export async function generateMetadata(): Promise<Metadata> {
   const maybeUser = await getMaybeUser();
   const [, federalState] = await dbGetFederalStateByIdWithResult(maybeUser?.federalStateId);

--- a/apps/chat-bot/src/app/logout/layout.tsx
+++ b/apps/chat-bot/src/app/logout/layout.tsx
@@ -1,6 +1,10 @@
 import { getUser } from '@/auth/utils';
 import React from 'react';
 
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false;
+
 export default async function Layout({ children }: { children: React.ReactNode }) {
   await getUser();
 

--- a/apps/chat-bot/src/components/chat/floating-text.tsx
+++ b/apps/chat-bot/src/components/chat/floating-text.tsx
@@ -9,8 +9,6 @@ import { cn } from '@/utils/tailwind';
 import ChevronDownIcon from '../icons/chevron-down';
 import ChevronRightIcon from '../icons/chevron-right';
 
-export const dynamic = 'force-dynamic';
-
 // Floating, minimizable, movable learning context dialog (desktop only) on mobile it's sticky on the top
 export function FloatingText({
   learningContext,

--- a/apps/chat-bot/src/components/hooks/use-persisted-overview-filter.ts
+++ b/apps/chat-bot/src/components/hooks/use-persisted-overview-filter.ts
@@ -80,19 +80,17 @@ export function usePersistedOverviewFilter(
   const selectedFilter = filter ?? 'mine';
   const [isLoading, setIsLoading] = useState(true);
   const onLoadRef = useRef(onLoad);
-  const lastLoadedFilterRef = useRef<OverviewFilter | null>(null);
 
   useEffect(() => {
     onLoadRef.current = onLoad;
   });
 
-  // Load data when filter is changed
+  // Load data whenever this effect (re-)runs: on mount, when filter changes, and when
+  // Next.js restores this route from its client-side segment cache (state persists, but
+  // the fetched list can be stale if the entity was created/edited elsewhere in the
+  // meantime), so refetch unconditionally rather than skipping repeats of the same filter.
   useEffect(() => {
-    if (lastLoadedFilterRef.current === filter) {
-      return;
-    }
     if (filter) {
-      lastLoadedFilterRef.current = filter;
       onLoadRef.current(filter).finally(() => startTransition(() => setIsLoading(false)));
     }
   }, [filter]);


### PR DESCRIPTION
Enables `cacheComponents: true` in both `chat-bot` and `admin`, dropping the redundant `experimental.useCache` flag.

- Removes `export const dynamic = 'force-dynamic'` across both apps — every route is dynamic by default under Cache Components now.
- Every route that blocks on request-time data (auth/session reads, dynamic params) is opted out of instant navigation via `export const instant = false`, found by running both apps with `pnpm dev` and checking the dev overlay plus the `next build` route table.
- `chat-bot`'s home page (`/`) generated a UUID before any request-time read, which Next tried to bake into the static shell; reordered the auth read to happen first so the UUID generation runs in an already-dynamic context, matching the pattern used by sibling "new conversation" pages.
- Fixes the assistants/characters/learning-scenarios overview lists staying stale after creating or editing an entity: `usePersistedOverviewFilter`'s fetch guard was blocking a refetch when the route was restored from Next's client-side segment cache.