### PR TITLE
TD-1478: Resolve instant-navigation warnings by Suspense-wrapping session reads

### DIFF
--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/[assistantId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/[assistantId]/page.tsx
@@ -6,6 +6,8 @@ import { AssistantView } from './assistant-view';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('assistants.page-titles');
@@ -14,8 +16,22 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/assistants/[assistantId]'>) {
-  const { assistantId } = await props.params;
+export default function Page(props: PageProps<'/assistants/[assistantId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({ params }: { params: PageProps<'/assistants/[assistantId]'>['params'] }) {
+  const { assistantId } = await params;
   const { user, federalState } = await requireAuth();
 
   const { assistant, fileMappings, pictureUrl } = await getAssistantByUser({

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/d/[assistantId]/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/d/[assistantId]/[conversationId]/page.tsx
@@ -13,6 +13,8 @@ import { getAvatarPictureUrl } from '@shared/files/fileService';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
@@ -23,11 +25,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(
-  props: PageProps<'/assistants/d/[assistantId]/[conversationId]'>,
-) {
-  const { assistantId, conversationId } = await props.params;
-  const searchParams = parseSearchParams(searchParamsSchema, await props.searchParams);
+export default function Page(props: PageProps<'/assistants/d/[assistantId]/[conversationId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+  searchParams: searchParamsPromise,
+}: PageProps<'/assistants/d/[assistantId]/[conversationId]'>) {
+  const { assistantId, conversationId } = await params;
+  const searchParams = parseSearchParams(searchParamsSchema, await searchParamsPromise);
   const { user, federalState } = await requireAuth();
   const userAndContext = {
     ...user,

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/d/[assistantId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/d/[assistantId]/page.tsx
@@ -11,6 +11,8 @@ import { getAvatarPictureUrl } from '@shared/files/fileService';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('assistants.page-titles');
@@ -19,8 +21,22 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/assistants/d/[assistantId]'>) {
-  const { assistantId } = await props.params;
+export default function Page(props: PageProps<'/assistants/d/[assistantId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({ params }: { params: PageProps<'/assistants/d/[assistantId]'>['params'] }) {
+  const { assistantId } = await params;
   const id = generateUUID();
   const { user, federalState } = await requireAuth();
   const userAndContext = {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/editor/[assistantId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/editor/[assistantId]/page.tsx
@@ -6,6 +6,8 @@ import { AssistantEdit } from './assistant-edit';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('assistants.page-titles');
@@ -14,8 +16,22 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/assistants/editor/[assistantId]'>) {
-  const { assistantId } = await props.params;
+export default function Page(props: PageProps<'/assistants/editor/[assistantId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({ params }: { params: PageProps<'/assistants/editor/[assistantId]'>['params'] }) {
+  const { assistantId } = await params;
   const { user, federalState } = await requireAuth();
 
   const { assistant, fileMappings, pictureUrl } = await getAssistantByUser({

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/assistants/page.tsx
@@ -3,6 +3,8 @@ import AssistantOverview from './assistant-overview';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('assistants.page-titles');
@@ -11,7 +13,21 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page() {
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent />
+    </Suspense>
+  );
+}
+
+async function PageContent() {
   const { user } = await requireAuth();
 
   return (

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/[characterId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/[characterId]/page.tsx
@@ -7,6 +7,8 @@ import { CharacterView } from './character-view';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');
@@ -15,8 +17,22 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/characters/[characterId]'>) {
-  const { characterId } = await props.params;
+export default function Page(props: PageProps<'/characters/[characterId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({ params }: { params: PageProps<'/characters/[characterId]'>['params'] }) {
+  const { characterId } = await params;
   const { user, federalState } = await requireAuth();
 
   const {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/d/[characterId]/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/d/[characterId]/[conversationId]/page.tsx
@@ -19,6 +19,8 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { NotFoundError } from '@shared/error';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
@@ -29,11 +31,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(
-  props: PageProps<'/characters/d/[characterId]/[conversationId]'>,
-) {
-  const params = await props.params;
-  const searchParams = parseSearchParams(searchParamsSchema, await props.searchParams);
+export default function Page(props: PageProps<'/characters/d/[characterId]/[conversationId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params: paramsPromise,
+  searchParams: searchParamsPromise,
+}: PageProps<'/characters/d/[characterId]/[conversationId]'>) {
+  const params = await paramsPromise;
+  const searchParams = parseSearchParams(searchParamsSchema, await searchParamsPromise);
   const { user, federalState } = await requireAuth();
   const userAndContext = {
     ...user,

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/d/[characterId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/d/[characterId]/page.tsx
@@ -14,6 +14,8 @@ import { LlmModelsProvider } from '@/components/providers/llm-model-provider';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
@@ -24,9 +26,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/characters/d/[characterId]'>) {
-  const { characterId } = await props.params;
-  const searchParams = parseSearchParams(searchParamsSchema, await props.searchParams);
+export default function Page(props: PageProps<'/characters/d/[characterId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+  searchParams: searchParamsPromise,
+}: PageProps<'/characters/d/[characterId]'>) {
+  const { characterId } = await params;
+  const searchParams = parseSearchParams(searchParamsSchema, await searchParamsPromise);
 
   const id = generateUUID();
   const { user, federalState } = await requireAuth();

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/page.tsx
@@ -8,6 +8,8 @@ import { redirect } from 'next/navigation';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');
@@ -16,8 +18,22 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/characters/editor/[characterId]'>) {
-  const { characterId } = await props.params;
+export default function Page(props: PageProps<'/characters/editor/[characterId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({ params }: { params: PageProps<'/characters/editor/[characterId]'>['params'] }) {
+  const { characterId } = await params;
   const { user, federalState } = await requireAuth();
 
   const {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/share/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/editor/[characterId]/share/page.tsx
@@ -6,6 +6,8 @@ import { notFound } from 'next/navigation';
 import { calculateShareSessionState } from '@shared/sharing/calculate-share-session-state';
 import { type Metadata } from 'next';
 import CustomChatSharePage from '@/components/custom-chat/custom-chat-share-page';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');
@@ -14,8 +16,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/characters/editor/[characterId]/share'>) {
-  const params = await props.params;
+export default function Page(props: PageProps<'/characters/editor/[characterId]/share'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params: paramsPromise,
+}: {
+  params: PageProps<'/characters/editor/[characterId]/share'>['params'];
+}) {
+  const params = await paramsPromise;
   const { user } = await requireAuth();
 
   const character = await getSharedCharacter({

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/layout.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/layout.tsx
@@ -1,7 +1,23 @@
 import { getUser } from '@/auth/utils';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
-export default async function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <LayoutContent>{children}</LayoutContent>
+    </Suspense>
+  );
+}
+
+async function LayoutContent({ children }: { children: React.ReactNode }) {
   const user = await getUser();
 
   if (user.userRole !== 'teacher') {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/characters/page.tsx
@@ -3,6 +3,8 @@ import CharacterOverview from './character-overview';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');
@@ -11,7 +13,21 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page() {
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent />
+    </Suspense>
+  );
+}
+
+async function PageContent() {
   const { user } = await requireAuth();
 
   return (

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/custom/editor/[customGptId]/layout.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/custom/editor/[customGptId]/layout.tsx
@@ -1,6 +1,22 @@
 import { getUser } from '@/auth/utils';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
-export default async function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <LayoutContent>{children}</LayoutContent>
+    </Suspense>
+  );
+}
+
+async function LayoutContent({ children }: { children: React.ReactNode }) {
   await getUser();
 
   return <>{children}</>;

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/custom/editor/[customGptId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/custom/editor/[customGptId]/page.tsx
@@ -4,15 +4,34 @@ import { parseSearchParams } from '@/utils/parse-search-params';
 import { getAssistantByUser } from '@shared/assistants/assistant-service';
 import { requireAuth } from '@/auth/requireAuth';
 import { handleErrorInServerComponent } from '@/error/handle-error-in-server-component';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 const searchParamsSchema = z.object({
   create: z.string().optional().default('false'),
   templateId: z.string().optional(),
 });
 
-export default async function Page(props: PageProps<'/custom/editor/[customGptId]'>) {
-  const { customGptId: assistantId } = await props.params;
-  const { create } = parseSearchParams(searchParamsSchema, await props.searchParams);
+export default function Page(props: PageProps<'/custom/editor/[customGptId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+  searchParams: searchParamsPromise,
+}: PageProps<'/custom/editor/[customGptId]'>) {
+  const { customGptId: assistantId } = await params;
+  const { create } = parseSearchParams(searchParamsSchema, await searchParamsPromise);
 
   const { user } = await requireAuth();
 
@@ -27,4 +46,5 @@ export default async function Page(props: PageProps<'/custom/editor/[customGptId
     permanentRedirect(`/assistants/${assistantId}`);
   }
   permanentRedirect(`/assistants/editor/${assistantId}${create === 'true' ? '?create=true' : ''}`);
+  return null;
 }

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/d/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/d/[conversationId]/page.tsx
@@ -15,6 +15,8 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { utils } from '@shared/utils';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('common.page-titles');
@@ -25,9 +27,26 @@ export async function generateMetadata(): Promise<Metadata> {
 
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
-export default async function Page(props: PageProps<'/d/[conversationId]'>) {
-  const { conversationId } = await props.params;
-  const searchParams = parseSearchParams(searchParamsSchema, await props.searchParams);
+export default function Page(props: PageProps<'/d/[conversationId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+  searchParams: searchParamsPromise,
+}: PageProps<'/d/[conversationId]'>) {
+  const { conversationId } = await params;
+  const searchParams = parseSearchParams(searchParamsSchema, await searchParamsPromise);
 
   const { user, federalState } = await requireAuth();
   const userAndContext = {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/image-generation/d/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/image-generation/d/[conversationId]/page.tsx
@@ -13,6 +13,8 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { ImageAspectRatioProvider } from '@/components/image-generation/image-aspect-ratio-provider';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('image-generation.page-titles');
@@ -25,8 +27,22 @@ interface PageProps {
   params: Promise<{ conversationId: string }>;
 }
 
-export default async function Page(props: PageProps) {
-  const { conversationId } = await props.params;
+export default function Page(props: PageProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({ params }: PageProps) {
+  const { conversationId } = await params;
   const { user, federalState } = await requireAuth();
 
   if (!federalState.featureToggles.isImageGenerationEnabled) {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/image-generation/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/image-generation/page.tsx
@@ -11,6 +11,8 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { ImageAspectRatioProvider } from '@/components/image-generation/image-aspect-ratio-provider';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('image-generation.page-titles');
@@ -19,7 +21,21 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function ImageGenerationPage() {
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent />
+    </Suspense>
+  );
+}
+
+async function PageContent() {
   const { federalState } = await requireAuth();
 
   if (!(federalState.featureToggles.isImageGenerationEnabled ?? false)) {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/layout.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/layout.tsx
@@ -1,5 +1,5 @@
 import { getUser, userHasCompletedTraining } from '@/auth/utils';
-import React from 'react';
+import React, { Suspense } from 'react';
 import { LlmModelsProvider } from '@/components/providers/llm-model-provider';
 import { dbGetLlmModelsByFederalStateId } from '@shared/db/functions/llm-model';
 import { getDefaultModelNameByFederalStateId } from '@shared/llm-models/llm-model-service';
@@ -21,8 +21,23 @@ import {
   getMaxBudgetInCentByUser,
   getUsedBudgetInCentByUser,
 } from '@shared/users/user-budget-service';
+import { Spinner } from '@ui/components/spinner';
 
-export default async function ChatLayout({ children }: { children: React.ReactNode }) {
+export default function ChatLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <ChatShell>{children}</ChatShell>
+    </Suspense>
+  );
+}
+
+async function ChatShell({ children }: { children: React.ReactNode }) {
   const t = await getTranslations('errors');
   const user = await getUser();
   if (!user.federalState.hasApiKeyAssigned) throw new Error(t('no-api-key'));

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/[learningScenarioId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/[learningScenarioId]/page.tsx
@@ -6,6 +6,8 @@ import { LearningScenarioView } from './learning-scenario-view';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');
@@ -14,8 +16,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/learning-scenarios/[learningScenarioId]'>) {
-  const { learningScenarioId } = await props.params;
+export default function Page(props: PageProps<'/learning-scenarios/[learningScenarioId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+}: {
+  params: PageProps<'/learning-scenarios/[learningScenarioId]'>['params'];
+}) {
+  const { learningScenarioId } = await params;
   const { user, federalState } = await requireAuth();
 
   const {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/d/[learningScenarioId]/[conversationId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/d/[learningScenarioId]/[conversationId]/page.tsx
@@ -18,6 +18,8 @@ import { getLearningScenarioForChatSession } from '@shared/learning-scenarios/le
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { NotFoundError } from '@shared/error';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
@@ -28,11 +30,28 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(
+export default function Page(
   props: PageProps<'/learning-scenarios/d/[learningScenarioId]/[conversationId]'>,
 ) {
-  const params = await props.params;
-  const searchParams = parseSearchParams(searchParamsSchema, await props.searchParams);
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params: paramsPromise,
+  searchParams: searchParamsPromise,
+}: PageProps<'/learning-scenarios/d/[learningScenarioId]/[conversationId]'>) {
+  const params = await paramsPromise;
+  const searchParams = parseSearchParams(searchParamsSchema, await searchParamsPromise);
   const { user, federalState } = await requireAuth();
   const userAndContext = {
     ...user,

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/d/[learningScenarioId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/d/[learningScenarioId]/page.tsx
@@ -13,6 +13,8 @@ import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { getLearningScenarioForChatSession } from '@shared/learning-scenarios/learning-scenario-service';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 const searchParamsSchema = z.object({ model: z.string().optional() });
 
@@ -23,9 +25,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(props: PageProps<'/learning-scenarios/d/[learningScenarioId]'>) {
-  const { learningScenarioId } = await props.params;
-  const searchParams = parseSearchParams(searchParamsSchema, await props.searchParams);
+export default function Page(props: PageProps<'/learning-scenarios/d/[learningScenarioId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+  searchParams: searchParamsPromise,
+}: PageProps<'/learning-scenarios/d/[learningScenarioId]'>) {
+  const { learningScenarioId } = await params;
+  const searchParams = parseSearchParams(searchParamsSchema, await searchParamsPromise);
 
   const id = generateUUID();
   const { user, federalState } = await requireAuth();

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/page.tsx
@@ -8,6 +8,8 @@ import { redirect } from 'next/navigation';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');
@@ -16,10 +18,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(
-  props: PageProps<'/learning-scenarios/editor/[learningScenarioId]'>,
-) {
-  const { learningScenarioId } = await props.params;
+export default function Page(props: PageProps<'/learning-scenarios/editor/[learningScenarioId]'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+}: {
+  params: PageProps<'/learning-scenarios/editor/[learningScenarioId]'>['params'];
+}) {
+  const { learningScenarioId } = await params;
   const { user, federalState } = await requireAuth();
 
   const {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/share/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/editor/[learningScenarioId]/share/page.tsx
@@ -6,6 +6,8 @@ import { handleErrorInServerComponent } from '@/error/handle-error-in-server-com
 import { notFound } from 'next/navigation';
 import { type Metadata } from 'next';
 import CustomChatSharePage from '@/components/custom-chat/custom-chat-share-page';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');
@@ -14,10 +16,28 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page(
+export default function Page(
   props: PageProps<'/learning-scenarios/editor/[learningScenarioId]/share'>,
 ) {
-  const { learningScenarioId } = await props.params;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+}: {
+  params: PageProps<'/learning-scenarios/editor/[learningScenarioId]/share'>['params'];
+}) {
+  const { learningScenarioId } = await params;
   const { user } = await requireAuth();
 
   const learningScenario = await getSharedLearningScenario({

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/layout.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/layout.tsx
@@ -1,7 +1,23 @@
 import { requireAuth } from '@/auth/requireAuth';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
-export default async function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <LayoutContent>{children}</LayoutContent>
+    </Suspense>
+  );
+}
+
+async function LayoutContent({ children }: { children: React.ReactNode }) {
   const { user } = await requireAuth();
 
   if (user.userRole !== 'teacher') {

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/learning-scenarios/page.tsx
@@ -3,6 +3,8 @@ import LearningScenarioOverview from './learning-scenario-overview';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');
@@ -11,7 +13,21 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page() {
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent />
+    </Suspense>
+  );
+}
+
+async function PageContent() {
   const { user } = await requireAuth();
 
   return (

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/page.tsx
@@ -9,6 +9,8 @@ import { requireAuth } from '@/auth/requireAuth';
 import { DefaultPageLayout } from '@/components/layout/default-page-layout';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('common.page-titles');
@@ -17,7 +19,21 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page() {
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent />
+    </Suspense>
+  );
+}
+
+async function PageContent() {
   const { user, federalState } = await requireAuth();
   const userAndContext = {
     ...user,

--- a/apps/chat-bot/src/app/(authed)/(chat-bot)/top-up/page.tsx
+++ b/apps/chat-bot/src/app/(authed)/(chat-bot)/top-up/page.tsx
@@ -3,6 +3,8 @@ import RedeemVoucherPage from './redeem-voucher-page';
 import { requireAuth } from '@/auth/requireAuth';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('top-up.page-titles');
@@ -11,7 +13,21 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page() {
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent />
+    </Suspense>
+  );
+}
+
+async function PageContent() {
   await requireAuth();
 
   return (

--- a/apps/chat-bot/src/app/(unauth)/login/page.tsx
+++ b/apps/chat-bot/src/app/(unauth)/login/page.tsx
@@ -5,6 +5,8 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { redirect } from 'next/navigation';
 import { getHostByHeaders } from '@/utils/host';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('common.page-titles');
@@ -13,7 +15,25 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page({
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string }>;
+}) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-dvh items-center justify-center">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent searchParams={searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
   searchParams,
 }: {
   searchParams: Promise<{ callbackUrl?: string }>;

--- a/apps/chat-bot/src/app/(unauth)/ua/characters/[characterId]/dialog/page.tsx
+++ b/apps/chat-bot/src/app/(unauth)/ua/characters/[characterId]/dialog/page.tsx
@@ -14,6 +14,8 @@ import { getTranslations } from 'next-intl/server';
 import { NextIntlClientProvider } from 'next-intl';
 import { resolveSharingLocale } from '@/i18n/sharing-locale';
 import { loadTranslations } from '@/i18n/load-translations';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('characters.page-titles');
@@ -24,9 +26,26 @@ export async function generateMetadata(): Promise<Metadata> {
 
 const searchParamsSchema = z.object({ inviteCode: z.string() });
 
-export default async function Page(props: PageProps<'/ua/characters/[characterId]/dialog'>) {
-  const { characterId } = await props.params;
-  const searchParams = parseSearchParams(searchParamsSchema, await props.searchParams);
+export default function Page(props: PageProps<'/ua/characters/[characterId]/dialog'>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-dvh items-center justify-center">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+  searchParams: searchParamsPromise,
+}: PageProps<'/ua/characters/[characterId]/dialog'>) {
+  const { characterId } = await params;
+  const searchParams = parseSearchParams(searchParamsSchema, await searchParamsPromise);
 
   const character = await dbGetCharacterByIdAndInviteCode({
     id: characterId,

--- a/apps/chat-bot/src/app/(unauth)/ua/learning-scenarios/[learningScenarioId]/dialog/page.tsx
+++ b/apps/chat-bot/src/app/(unauth)/ua/learning-scenarios/[learningScenarioId]/dialog/page.tsx
@@ -14,6 +14,8 @@ import { getTranslations } from 'next-intl/server';
 import { NextIntlClientProvider } from 'next-intl';
 import { resolveSharingLocale } from '@/i18n/sharing-locale';
 import { loadTranslations } from '@/i18n/load-translations';
+import { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('learning-scenarios.page-titles');
@@ -24,11 +26,28 @@ export async function generateMetadata(): Promise<Metadata> {
 
 const searchParamsSchema = z.object({ inviteCode: z.string() });
 
-export default async function Page(
+export default function Page(
   props: PageProps<'/ua/learning-scenarios/[learningScenarioId]/dialog'>,
 ) {
-  const { learningScenarioId } = await props.params;
-  const searchParams = parseSearchParams(searchParamsSchema, await props.searchParams);
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-dvh items-center justify-center">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <PageContent params={props.params} searchParams={props.searchParams} />
+    </Suspense>
+  );
+}
+
+async function PageContent({
+  params,
+  searchParams: searchParamsPromise,
+}: PageProps<'/ua/learning-scenarios/[learningScenarioId]/dialog'>) {
+  const { learningScenarioId } = await params;
+  const searchParams = parseSearchParams(searchParamsSchema, await searchParamsPromise);
 
   const learningScenario = await dbGetLearningScenarioByIdAndInviteCode({
     learningScenarioId,

--- a/apps/chat-bot/src/app/logout/layout.tsx
+++ b/apps/chat-bot/src/app/logout/layout.tsx
@@ -1,7 +1,22 @@
 import { getUser } from '@/auth/utils';
-import React from 'react';
+import React, { Suspense } from 'react';
+import { Spinner } from '@ui/components/spinner';
 
-export default async function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-dvh items-center justify-center">
+          <Spinner className="size-8" />
+        </div>
+      }
+    >
+      <LayoutContent>{children}</LayoutContent>
+    </Suspense>
+  );
+}
+
+async function LayoutContent({ children }: { children: React.ReactNode }) {
   await getUser();
 
   return <>{children}</>;

--- a/apps/chat-bot/src/auth/requireAuth.ts
+++ b/apps/chat-bot/src/auth/requireAuth.ts
@@ -8,6 +8,8 @@ export async function requireAuth(): Promise<{
   user: UserModel;
   federalState: FederalStateModel;
 }> {
+  'use cache: private';
+
   const session = await auth();
   if (!session) {
     const headersList = await headers();

--- a/apps/chat-bot/src/auth/utils.ts
+++ b/apps/chat-bot/src/auth/utils.ts
@@ -50,6 +50,8 @@ export async function getMaybeUser() {
 }
 
 export async function getUser(): Promise<UserAndContext> {
+  'use cache: private';
+
   const session = await getValidSession();
 
   if (session.user === undefined) {
@@ -60,6 +62,8 @@ export async function getUser(): Promise<UserAndContext> {
 }
 
 export async function userHasCompletedTraining(): Promise<boolean> {
+  'use cache: private';
+
   const session = await getMaybeSession();
   return session?.hasCompletedTraining ?? false;
 }

--- a/apps/chat-bot/src/auth/utils.ts
+++ b/apps/chat-bot/src/auth/utils.ts
@@ -35,12 +35,16 @@ export function redirectToLogin(pathname: string): never {
 }
 
 export async function getMaybeSession(): Promise<Session | null> {
+  'use cache: private';
+
   const session = await auth();
 
   return session;
 }
 
 export async function getMaybeUser() {
+  'use cache: private';
+
   const session = await auth();
   const user = session?.user;
 

--- a/apps/chat-bot/src/components/hooks/use-persisted-overview-filter.ts
+++ b/apps/chat-bot/src/components/hooks/use-persisted-overview-filter.ts
@@ -80,19 +80,17 @@ export function usePersistedOverviewFilter(
   const selectedFilter = filter ?? 'mine';
   const [isLoading, setIsLoading] = useState(true);
   const onLoadRef = useRef(onLoad);
-  const lastLoadedFilterRef = useRef<OverviewFilter | null>(null);
 
   useEffect(() => {
     onLoadRef.current = onLoad;
   });
 
-  // Load data when filter is changed
+  // Load data whenever this effect (re-)runs: on mount, when filter changes, and when
+  // Next.js restores this route from its client-side segment cache (state persists, but
+  // the fetched list can be stale if the entity was created/edited elsewhere in the
+  // meantime), so refetch unconditionally rather than skipping repeats of the same filter.
   useEffect(() => {
-    if (lastLoadedFilterRef.current === filter) {
-      return;
-    }
     if (filter) {
-      lastLoadedFilterRef.current = filter;
       onLoadRef.current(filter).finally(() => startTransition(() => setIsLoading(false)));
     }
   }, [filter]);


### PR DESCRIPTION
Follows up on #1272 to resolve the dev-time instant-navigation warnings that Cache Components flags for every route reading the user session, per Next's [authentication-with-cache-components guide](https://nextjs.org/docs/app/guides/authentication-with-cache-components).

- Cache session reads with `"use cache: private"` (`requireAuth()`, `getUser()`, `getMaybeUser()`, `getMaybeSession()`) so they're cached in the browser instead of blocking.
- Split the shared chat-bot layout and every authed leaf route (assistants, characters, learning-scenarios, image-generation, home, `d/[conversationId]`, `custom/editor`, `top-up`) into a thin wrapper + an async component behind `<Suspense>`, so the session read no longer blocks outside a boundary.
- Same treatment for `/login`, `/logout`, and the public `/ua/*` shared-chat dialog routes, which had no Suspense boundary at all and surfaced the same warning via the root layout.
- Along the way, fixed a pre-existing bug: the assistants/characters/learning-scenarios overview lists stayed stale after creating or editing an entity and navigating back via a soft (client-side) navigation, because a fetch-guard in `usePersistedOverviewFilter` blocked a legitimate refetch when Next restored the route from its client-side segment cache.

Root layout's own session + theming read is intentionally left as a documented `instant = false` Block (not in scope here).